### PR TITLE
Clean WeaponSlotInfo from base CfgWeapons

### DIFF
--- a/Compatibility/hlc_CUP_Compat_AR15/config.cpp
+++ b/Compatibility/hlc_CUP_Compat_AR15/config.cpp
@@ -14,7 +14,6 @@ class CfgPatches
 class SlotInfo;
 class CfgWeapons
 {
-	class WeaponSlotsInfo;
 	class ItemCore;
 	class InventoryMuzzleItem_Base_F;
 	class Rifle;

--- a/Compatibility/hlc_CUP_Compat_AUG/config.cpp
+++ b/Compatibility/hlc_CUP_Compat_AUG/config.cpp
@@ -13,7 +13,6 @@ class CfgPatches
 };
 class CfgWeapons
 {
-	class WeaponSlotsInfo;
 	class ItemCore;
 	class InventoryMuzzleItem_Base_F;
 	class Rifle;

--- a/Compatibility/hlc_CUP_Compat_AWC/config.cpp
+++ b/Compatibility/hlc_CUP_Compat_AWC/config.cpp
@@ -13,7 +13,6 @@ class CfgPatches
 };
 class CfgWeapons
 {
-	class WeaponSlotsInfo;
 	class ItemCore;
 	class InventoryMuzzleItem_Base_F;
 	class Rifle;

--- a/Compatibility/hlc_CUP_Compat_M14/config.cpp
+++ b/Compatibility/hlc_CUP_Compat_M14/config.cpp
@@ -14,7 +14,6 @@ class CfgPatches
 class SlotInfo;
 class CfgWeapons
 {
-	class WeaponSlotsInfo;
 	class ItemCore;
 	class InventoryMuzzleItem_Base_F;
 	class Rifle;

--- a/Compatibility/hlc_CUP_Compat_M60E4/config.cpp
+++ b/Compatibility/hlc_CUP_Compat_M60E4/config.cpp
@@ -13,7 +13,6 @@ class CfgPatches
 };
 class CfgWeapons
 {
-	class WeaponSlotsInfo;
 	class ItemCore;
 	class InventoryMuzzleItem_Base_F;
 	class Rifle;

--- a/Compatibility/hlc_CUP_Compat_MP5/config.cpp
+++ b/Compatibility/hlc_CUP_Compat_MP5/config.cpp
@@ -13,7 +13,6 @@ class CfgPatches
 };
 class CfgWeapons
 {
-	class WeaponSlotsInfo;
 	class ItemCore;
 	class InventoryMuzzleItem_Base_F;
 	class Rifle;

--- a/Compatibility/hlc_CUP_Compat_SAW/config.cpp
+++ b/Compatibility/hlc_CUP_Compat_SAW/config.cpp
@@ -13,7 +13,6 @@ class CfgPatches
 };
 class CfgWeapons
 {
-	class WeaponSlotsInfo;
 	class ItemCore;
 	class InventoryMuzzleItem_Base_F;
 	class Rifle;

--- a/Compatibility/hlc_ace3_compat_AUG/config.cpp
+++ b/Compatibility/hlc_ace3_compat_AUG/config.cpp
@@ -13,7 +13,6 @@ class CfgPatches
 };
 class CfgWeapons
 {
-	class WeaponSlotsInfo;
 	class ItemCore;
 	class InventoryMuzzleItem_Base_F;
 	class Rifle;

--- a/Compatibility/hlc_ace3_compat_MP5/config.cpp
+++ b/Compatibility/hlc_ace3_compat_MP5/config.cpp
@@ -13,7 +13,6 @@ class CfgPatches
 };
 class CfgWeapons
 {
-	class WeaponSlotsInfo;
 	class ItemCore;
 	class InventoryMuzzleItem_Base_F;
 	class Rifle;

--- a/Compatibility/hlc_ace3_compat_SIGAMT/config.cpp
+++ b/Compatibility/hlc_ace3_compat_SIGAMT/config.cpp
@@ -12,15 +12,10 @@ class CfgPatches
 	};
 };
 
-class ItemCore;
-class InventoryItem_Base_F;
-class InventoryMuzzleItem_Base_F;
-class InventoryFlashLightItem_Base_F;
-class InventoryOpticsItem_Base_F;
-
 class CfgWeapons
 {
     class ItemCore;
+    class InventoryOpticsItem_Base_F;
     class optic_Arco : ItemCore{};
 
     class hlc_optic_Kern :optic_arco

--- a/Compatibility/hlc_rhs_Compat_AR15/config.cpp
+++ b/Compatibility/hlc_rhs_Compat_AR15/config.cpp
@@ -14,7 +14,6 @@ class CfgPatches
 class SlotInfo;
 class CfgWeapons
 {
-	class WeaponSlotsInfo;
 	class ItemCore;
 	class InventoryMuzzleItem_Base_F;
 	class Rifle;

--- a/Compatibility/hlc_rhs_compat_AUG/config.cpp
+++ b/Compatibility/hlc_rhs_compat_AUG/config.cpp
@@ -13,7 +13,6 @@ class CfgPatches
 };
 class CfgWeapons
 {
-	class WeaponSlotsInfo;
 	class ItemCore;
 	class InventoryMuzzleItem_Base_F;
 	class Rifle;

--- a/Compatibility/hlc_rhs_compat_AWC/config.cpp
+++ b/Compatibility/hlc_rhs_compat_AWC/config.cpp
@@ -13,7 +13,6 @@ class CfgPatches
 };
 class CfgWeapons
 {
-	class WeaponSlotsInfo;
 	class ItemCore;
 	class InventoryMuzzleItem_Base_F;
 	class Rifle;

--- a/Compatibility/hlc_rhs_compat_M14/config.cpp
+++ b/Compatibility/hlc_rhs_compat_M14/config.cpp
@@ -14,7 +14,6 @@ class CfgPatches
 class SlotInfo;
 class CfgWeapons
 {
-	class WeaponSlotsInfo;
 	class ItemCore;
 	class InventoryMuzzleItem_Base_F;
 	class Rifle;

--- a/Compatibility/hlc_rhs_compat_M60E4/config.cpp
+++ b/Compatibility/hlc_rhs_compat_M60E4/config.cpp
@@ -13,7 +13,6 @@ class CfgPatches
 };
 class CfgWeapons
 {
-	class WeaponSlotsInfo;
 	class ItemCore;
 	class InventoryMuzzleItem_Base_F;
 	class Rifle;

--- a/Compatibility/hlc_rhs_compat_MP5/config.cpp
+++ b/Compatibility/hlc_rhs_compat_MP5/config.cpp
@@ -13,7 +13,6 @@ class CfgPatches
 };
 class CfgWeapons
 {
-	class WeaponSlotsInfo;
 	class ItemCore;
 	class InventoryMuzzleItem_Base_F;
 	class Rifle;

--- a/Compatibility/hlc_rhs_compat_SAW/config.cpp
+++ b/Compatibility/hlc_rhs_compat_SAW/config.cpp
@@ -11,30 +11,7 @@ class CfgPatches
 		author = "Toadie";
 	};
 };
-class SlotInfo;
-class CowsSlot;
-class PointerSlot;
-class asdg_FrontSideRail;
-class asdg_OpticRail1913;
-class asdg_OpticRail1913_short;
-class asdg_OpticSideMount;
-class asdg_UnderSlot;
-class asdg_MuzzleSlot;
-class asdg_MuzzleSlot_556;
-class WeaponSlotsInfo;
-class ItemCore;
-class InventoryMuzzleItem_Base_F;
-class Rifle;
-class Rifle_Base_F : Rifle
-{
-	class WeaponSlotsInfo;
-	class GunParticles;
-};
-class Rifle_Long_Base_F : Rifle_Base_F
-{
-	class WeaponSlotsInfo;
-};
-class UGL_F;
+
 class CfgWeapons
 {
 

--- a/hlc_core/config.cpp
+++ b/hlc_core/config.cpp
@@ -93,13 +93,6 @@ class Mode_FullAuto;
 class SlotInfo;
 class CowsSlot;
 class PointerSlot;
-class ebr_base_f;
-class ItemCore;
-class InventoryItem_Base_F;
-class InventoryMuzzleItem_Base_F;
-class InventoryFlashLightItem_Base_F;
-class InventoryOpticsItem_Base_F;
-class GrenadeLauncher;
 
 class CfgMovesBasic {
      class DefaultDie;

--- a/hlc_wp_minigun/config.cpp
+++ b/hlc_wp_minigun/config.cpp
@@ -26,13 +26,6 @@ class SlotInfo;
 class CowsSlot;
 class PointerSlot;
 
-class ItemCore;
-class InventoryItem_Base_F;
-class InventoryMuzzleItem_Base_F;
-class InventoryFlashLightItem_Base_F;
-class InventoryOpticsItem_Base_F;
-class GrenadeLauncher;
-
 class cfgMods {
     class mod_base;
 

--- a/hlc_wp_saw/config.cpp
+++ b/hlc_wp_saw/config.cpp
@@ -42,12 +42,6 @@ class SlotInfo;
 class CowsSlot;
 class PointerSlot;
 
-class ItemCore;
-class InventoryItem_Base_F;
-class InventoryMuzzleItem_Base_F;
-class InventoryFlashLightItem_Base_F;
-class InventoryOpticsItem_Base_F;
-class GrenadeLauncher;
 class asdg_FrontSideRail;
 class asdg_OpticRail;
 class asdg_OpticRail1913;

--- a/hlc_wp_sigamt/config.cpp
+++ b/hlc_wp_sigamt/config.cpp
@@ -43,12 +43,6 @@ class SlotInfo;
 class CowsSlot;
 class PointerSlot;
 
-class ItemCore;
-class InventoryItem_Base_F;
-class InventoryMuzzleItem_Base_F;
-class InventoryFlashLightItem_Base_F;
-class InventoryOpticsItem_Base_F;
-class GrenadeLauncher;
 class asdg_FrontSideRail;
 class asdg_OpticRail1913;
 class asdg_OpticRail1913_short;

--- a/hlc_wp_springfield/config.cpp
+++ b/hlc_wp_springfield/config.cpp
@@ -44,12 +44,6 @@ class SlotInfo;
 class CowsSlot;
 class PointerSlot;
 
-class ItemCore;
-class InventoryItem_Base_F;
-class InventoryMuzzleItem_Base_F;
-class InventoryFlashLightItem_Base_F;
-class InventoryOpticsItem_Base_F;
-class GrenadeLauncher;
 class asdg_FrontSideRail;
 class asdg_OpticRail1913;
 class asdg_OpticRail1913_short;


### PR DESCRIPTION
Fix #37

Also cleanup other configs (e.g. ItemCore) defined at base level that
should be under cfgWeapons.