### PR TITLE
Make MG belts into ACE belts

### DIFF
--- a/hlc_core/CfgMagazines.hpp
+++ b/hlc_core/CfgMagazines.hpp
@@ -195,6 +195,7 @@ class CfgMagazines {
         mass = 27;
         displaynameshort = "M80A1 EPR";
         nameSound = "mgun";
+        ACE_isBelt = 1;
     };
     class hlc_100Rnd_762x51_M_M60E4 : hlc_100Rnd_762x51_B_M60E4 {
         dlc = "Niarms_M60";

--- a/hlc_wp_mg3/config.cpp
+++ b/hlc_wp_mg3/config.cpp
@@ -204,7 +204,7 @@ class CfgAmmo
         ACE_barrelLengths[] = { 508.0, 599.948, 660.4 };
     };
     //SmK Tracer/SmK -v
-    //SmK Spitzgescho� mit Kern Leuchtspur /
+    //SmK Spitzgeschoß mit Kern Leuchtspur /
     /*
     884.9 typicalSpeed
 11.57 hit
@@ -246,7 +246,7 @@ class CfgAmmo
         ACE_barrelLengths[] = { 508.0, 599.948, 660.4 };
     };
     //SmK AP
-    //SmK Spitzgescho� mit Hartkern  
+    //SmK Spitzgeschoß mit Hartkern  
     /*
     853.44 typicalSpeed
     9.9925 hit

--- a/hlc_wp_mg3/config.cpp
+++ b/hlc_wp_mg3/config.cpp
@@ -204,7 +204,7 @@ class CfgAmmo
         ACE_barrelLengths[] = { 508.0, 599.948, 660.4 };
     };
     //SmK Tracer/SmK -v
-    //SmK Spitzgeschoß mit Kern Leuchtspur /
+    //SmK Spitzgeschoï¿½ mit Kern Leuchtspur /
     /*
     884.9 typicalSpeed
 11.57 hit
@@ -246,7 +246,7 @@ class CfgAmmo
         ACE_barrelLengths[] = { 508.0, 599.948, 660.4 };
     };
     //SmK AP
-    //SmK Spitzgeschoß mit Hartkern  
+    //SmK Spitzgeschoï¿½ mit Hartkern  
     /*
     853.44 typicalSpeed
     9.9925 hit
@@ -402,6 +402,7 @@ class CfgMagazines{
         mass = 40;
         displaynameshort = "7.92mm FMJ";
         nameSound = "mgun";
+        ACE_isBelt = 1;
     };
     class hlc_100Rnd_792x57_B_MG42 : hlc_50Rnd_792x57_B_MG42 {
         dlc = "Niarms_MG3";

--- a/hlc_wp_saw/config.cpp
+++ b/hlc_wp_saw/config.cpp
@@ -232,6 +232,7 @@ class CfgMagazines{
         mass = 58;
         displaynameshort = "EPR/Tracer";
         nameSound = "mgun";
+        ACE_isBelt = 1;
     };
     class hlc_200rnd_556x45_T_SAW : hlc_200rnd_556x45_M_SAW {
         dlc = "Niarms_SAW";


### PR DESCRIPTION
This pull will make MG belts into ACE belts so they can be repacked faster and be linked by an assistant.

Covers Minimi/M249/Mk46, MG3/42 and M60/Mk48. Only touches the base mag that all the other mags inherit from.