### PR TITLE
Fixing formatting for drySound, reloadMagazineSound and changeFiremod…

### DIFF
--- a/hlc_wp_ACR/config.cpp
+++ b/hlc_wp_ACR/config.cpp
@@ -482,7 +482,7 @@ class hlc_acr_base : Rifle_Base_F {
         __AI_ROF_RIFLE_SMALL_HSCOPE_SINGLE;
     };
 
-    drysound[] = { "\hlc_core\sound\empty_assaultrifles", 1, 1, 10 };
+    drysound[] = { "hlc_core\sound\empty_assaultrifles", 1, 1, 10 };
     reloadMagazineSound[] = { "hlc_wp_acr\snd\ACR_reload", 0.74, 1, 30 };
     changeFiremodeSound[] = { "hlc_wp_acr\snd\ar15_selector", 1, 1, 8 };
     UiPicture = "\A3\weapons_f\data\UI\icon_regular_CA.paa";

--- a/hlc_wp_AR15/config.cpp
+++ b/hlc_wp_AR15/config.cpp
@@ -327,9 +327,9 @@ class CfgWeapons {
             __AI_ROF_RIFLE_SMALL_HSCOPE_SINGLE;
         };
 
-        drysound[] = {"\hlc_wp_ar15\snd\ar15_trigger", 1, 1, 10};
-        reloadMagazineSound[] = {"\hlc_wp_ar15\snd\ar15_reload_A3_std",0.74,1,30};
-        changeFiremodeSound[] = { "\hlc_wp_ar15\snd\ar15_selector", 1, 1, 8 };
+        drysound[] = {"hlc_wp_ar15\snd\ar15_trigger", 1, 1, 10};
+        reloadMagazineSound[] = {"hlc_wp_ar15\snd\ar15_reload_A3_std",0.74,1,30};
+        changeFiremodeSound[] = { "hlc_wp_ar15\snd\ar15_selector", 1, 1, 8 };
         UiPicture = "\A3\weapons_f\data\UI\icon_regular_CA.paa";
 
         class hlc_M203 : UGL_F {

--- a/hlc_wp_ak/config.cpp
+++ b/hlc_wp_ak/config.cpp
@@ -964,8 +964,8 @@ class CfgWeapons {
                 burst = 2; 
                 textureType = "dual"; 
         };
-        drysound[] = {"\hlc_wp_ak\snd\empty_assaultrifles", 1, 1, 10};
-        reloadMagazineSound[] = { "\hlc_wp_ak\snd\soundshaders\ak74\ak74m_reload", 0.8, 1, 20 };
+        drysound[] = {"hlc_wp_ak\snd\empty_assaultrifles", 1, 1, 10};
+        reloadMagazineSound[] = { "hlc_wp_ak\snd\soundshaders\ak74\ak74m_reload", 0.8, 1, 20 };
         aidispersioncoefx = 4;
         aidispersioncoefy = 6;
 
@@ -2435,7 +2435,7 @@ class CfgWeapons {
         hiddenSelections[] = { "Main" };
         hiddenSelectionsTextures[] = { "hlc_wp_ak\tex\nix_rk62\rk62_co.paa" };
         displayName = "Valmet Rk.62";
-        drysound[] = { "\hlc_wp_ak\snd\empty_assaultrifles", 1.5, 1, 10 };
+        drysound[] = { "hlc_wp_ak\snd\empty_assaultrifles", 1.5, 1, 10 };
         reloadMagazineSound[] = { "\hlc_wp_ak\snd\soundshaders\rk62\rk62_reload", 1, 1, 20 };
         reloadAction = "HLC_GestureReloadAK";
         recoil = "recoil_mx";

--- a/hlc_wp_aug/config.cpp
+++ b/hlc_wp_aug/config.cpp
@@ -812,7 +812,7 @@ class CfgWeapons {
             showToPlayer = 0;
             __AI_ROF_RIFLE_SMALL_HSCOPE_SINGLE;
         };
-        drysound[] = { "\hlc_wp_aug\snd\clipempty_rifle", 1, 1, 10 };
+        drysound[] = { "hlc_wp_aug\snd\clipempty_rifle", 1, 1, 10 };
         reloadMagazineSound[] = { "hlc_wp_aug\snd\f88a1_reload2", 1, 1, 30 };
 
         class ItemInfo {

--- a/hlc_wp_fhAWC/config.cpp
+++ b/hlc_wp_fhAWC/config.cpp
@@ -428,8 +428,8 @@ class CfgWeapons {
         aiDispersionCoefY = 10;
         aiDispersionCoefX = 8;
 
-        drysound[] = { "\hlc_wp_fhawc\snd\AWC_dryfire", 1, 1, 10 };
-        reloadmagazinesound[] = { "\hlc_wp_fhawc\snd\AWC_reload", 0.5, 1, 20 };
+        drysound[] = { "hlc_wp_fhawc\snd\AWC_dryfire", 1, 1, 10 };
+        reloadmagazinesound[] = { "hlc_wp_fhawc\snd\AWC_reload", 0.5, 1, 20 };
 
         class ItemInfo {
             priority = 1;

--- a/hlc_wp_g3/config.cpp
+++ b/hlc_wp_g3/config.cpp
@@ -630,7 +630,7 @@ class CfgWeapons {
 
 
     class hlc_g3_base : Rifle_Base_F {
-        changeFiremodeSound[] = { "\hlc_wp_g3\snd\SWITCH6", 1, 1, 8 };
+        changeFiremodeSound[] = { "hlc_wp_g3\snd\SWITCH6", 1, 1, 8 };
         dlc = "Niarms_G3";
         recoil = "recoil_dmr_03";
         magazineReloadSwitchPhase = 0.5;
@@ -762,8 +762,8 @@ class CfgWeapons {
             burst = 4;
             __AI_ROF_RIFLE_MEDIUM_CLOSE_BURST;
         };
-        drysound[] = {"\hlc_core\sound\empty_sniperrifles", 1, 1, 10};
-        // reloadMagazineSound[] = {"\hlc_wp_ak\snd\ak74m_reload",0.74,1,30};
+        drysound[] = {"hlc_core\sound\empty_sniperrifles", 1, 1, 10};
+        // reloadMagazineSound[] = {"hlc_wp_ak\snd\ak74m_reload",0.74,1,30};
         UiPicture = "\A3\weapons_f\data\UI\icon_regular_CA.paa";
     };
 

--- a/hlc_wp_g36/config.cpp
+++ b/hlc_wp_g36/config.cpp
@@ -713,7 +713,7 @@ class CfgWeapons {
         bullet9[] = {"A3\sounds_f\weapons\shells\7_62\grass_762_01", 0.281838, 1, 15};
         drysound[] = { "hlc_wp_g36\snd\g36_dryfire", 1.01, 1, 10 };
         reloadmagazinesound[] = { "hlc_wp_g36\snd\G36_reload", 0.9, 1, 35 };
-        changeFiremodeSound[] = { "\hlc_wp_g36\snd\g36_switch", 1, 1, 8 };
+        changeFiremodeSound[] = { "hlc_wp_g36\snd\g36_switch", 1, 1, 8 };
         UiPicture = "\A3\weapons_f\data\UI\icon_regular_CA.paa";
 
         class hlc_GL_AG36 : UGL_F {

--- a/hlc_wp_m14/config.cpp
+++ b/hlc_wp_m14/config.cpp
@@ -576,8 +576,8 @@ class CfgWeapons {
             __AI_ROF_RIFLE_MEDIUM_CLOSE_BURST;
         };
 
-        drysound[] = { "\hlc_wp_m14\snd\soundshaders\m14_dry", 1, 1, 10 };
-        reloadmagazinesound[] = { "\hlc_wp_M14\snd\soundshaders\m14_reload", 0.7, 1, 18 };
+        drysound[] = { "hlc_wp_m14\snd\soundshaders\m14_dry", 1, 1, 10 };
+        reloadmagazinesound[] = { "hlc_wp_M14\snd\soundshaders\m14_reload", 0.7, 1, 18 };
         reloadaction = "HLC_GestureReloadm14";
         UiPicture = "\A3\weapons_f\data\UI\icon_regular_CA.paa";
     };

--- a/hlc_wp_m60E4/config.cpp
+++ b/hlc_wp_m60E4/config.cpp
@@ -216,8 +216,8 @@ class CfgWeapons {
             aiRateOfFireDistance = 900;
         };
 
-        drysound[] = {"\hlc_core\sound\empty_machineguns", 1, 1, 10};
-        reloadmagazinesound[] = {"\hlc_wp_M60E4\snd\m60_reload", 1, 1,10};
+        drysound[] = {"hlc_core\sound\empty_machineguns", 1, 1, 10};
+        reloadmagazinesound[] = {"hlc_wp_M60E4\snd\m60_reload", 1, 1,10};
     };
     class hlc_lmg_M60E4 : hlc_M60e4_base {
         maxZeroing = 1100;

--- a/hlc_wp_mg3/config.cpp
+++ b/hlc_wp_mg3/config.cpp
@@ -694,8 +694,8 @@ class CfgWeapons {
             __AI_ROF_MG_VERYFAR_SCOPE_BURST;
         };
 
-        drysound[] = { "\hlc_wp_mg3\snd\mg3_dryfire", 1, 1, 10 };
-        reloadmagazinesound[] = { "\hlc_wp_mg3\snd\mg42_reload", 0.8, 1, 18 };
+        drysound[] = { "hlc_wp_mg3\snd\mg3_dryfire", 1, 1, 10 };
+        reloadmagazinesound[] = { "hlc_wp_mg3\snd\mg42_reload", 0.8, 1, 18 };
         soundBipodDown[] = { "A3\Sounds_F_Mark\arsenal\sfx\bipods\Bipod_AAF_down", db - 3, 1, 20 }; /// sound of unfolding the bipod
         soundBipodUp[] = { "A3\Sounds_F_Mark\arsenal\sfx\bipods\Bipod_AAF_up", db - 3, 1, 20 }; /// sound of folding the bipod
         UiPicture = "\A3\weapons_f\data\UI\icon_mg_CA.paa";

--- a/hlc_wp_minigun/config.cpp
+++ b/hlc_wp_minigun/config.cpp
@@ -358,7 +358,7 @@ class CfgWeapons {
             aiRateOfFire = 2.0;
             aiRateOfFireDistance = 200;
         };
-        drysound[] = { "\hlc_wp_minigun\snd\m134_dryfire", 1, 1, 10 };
-        reloadMagazineSound[] = { "\hlc_wp_minigun\snd\m134_reload", 0.74, 1, 17 };
+        drysound[] = { "hlc_wp_minigun\snd\m134_dryfire", 1, 1, 10 };
+        reloadMagazineSound[] = { "hlc_wp_minigun\snd\m134_reload", 0.74, 1, 17 };
     };
 };

--- a/hlc_wp_mp5/config.cpp
+++ b/hlc_wp_mp5/config.cpp
@@ -311,7 +311,7 @@ class CfgWeapons {
         ACE_barrelLength = 228.6;
         drysound[] = {"hlc_wp_mp5\snd\mp5_dryfire", 1, 1, 20};
         changeFiremodeSound[] = { "hlc_wp_mp5\snd\mp5_safety", 1, 1, 8 };
-        reloadmagazinesound[] = { "\hlc_wp_MP5\snd\mp5_reload_empty", 0.7, 1, 20 };
+        reloadmagazinesound[] = { "hlc_wp_MP5\snd\mp5_reload_empty", 0.7, 1, 20 };
         magazines[] = {"hlc_30Rnd_9x19_B_MP5", "hlc_30Rnd_9x19_GD_MP5", "hlc_30Rnd_9x19_SD_MP5"};
         maxRecoilSway = 0.0125;
         swayDecaySpeed = 1.25;

--- a/hlc_wp_p226/config.cpp
+++ b/hlc_wp_p226/config.cpp
@@ -1037,8 +1037,8 @@ class CfgWeapons {
         bullet12[] = { "A3\sounds_f\weapons\shells\9mm\grass_9mm_04", 0.22387211, 1, 15 };
         soundBullet[] = { "bullet1", 0.083, "bullet2", 0.083, "bullet3", 0.083, "bullet4", 0.083, "bullet5", 0.083, "bullet6", 0.083, "bullet7", 0.083, "bullet8", 0.083, "bullet9", 0.083, "bullet10", 0.083, "bullet11", 0.083, "bullet12", 0.083 };
         drysound[] = { "hlc_wp_p226\snd\p226_dryfire", 1, 1, 20 };
-        changeFiremodeSound[] = { "\hlc_wp_p226\snd\p226_dryfire", 1, 1, 8 };
-        reloadmagazinesound[] = { "\hlc_wp_p226\snd\p226_reload", 0.7, 1, 20 };
+        changeFiremodeSound[] = { "hlc_wp_p226\snd\p226_dryfire", 1, 1, 8 };
+        reloadmagazinesound[] = { "hlc_wp_p226\snd\p226_reload", 0.7, 1, 20 };
         sounds[] = { "StandardSound", "SilencedSound" };
 
         modes[] = { "Single" };

--- a/hlc_wp_saw/config.cpp
+++ b/hlc_wp_saw/config.cpp
@@ -396,8 +396,8 @@ class CfgWeapons {
         };
         __AI_DISPERSION_COEF;
 
-        drysound[] = {"\hlc_core\sound\empty_machineguns", 1, 1, 10};
-        reloadmagazinesound[] = {"\hlc_core\sound\empty_machineguns", 0.5, 1};
+        drysound[] = {"hlc_core\sound\empty_machineguns", 1, 1, 10};
+        reloadmagazinesound[] = {"hlc_core\sound\empty_machineguns", 0.5, 1};
     };
     class hlc_lmg_minimipara : hlc_saw_base {
         dlc = "Niarms_SAW";
@@ -431,8 +431,8 @@ class CfgWeapons {
         model = "\hlc_wp_saw\mesh\minimi_para\minimi.p3d";
         reloadaction = "HLC_GestureReloadM249";
         descriptionShort = "Light Machine Gun<br/>Caliber: 5.56mm";
-        drysound[] = { "\hlc_wp_saw\snd\empty_machineguns", 1, 1, 10 };
-        reloadmagazinesound[] = { "\hlc_wp_saw\snd\soundshaders\SAW\saw_reload", 0.7, 1, 20 };
+        drysound[] = { "hlc_wp_saw\snd\empty_machineguns", 1, 1, 10 };
+        reloadmagazinesound[] = { "hlc_wp_saw\snd\soundshaders\SAW\saw_reload", 0.7, 1, 20 };
         inertia = 0.65;
         __DEXTERITY(6.56, 0);
         picture = "\hlc_wp_saw\tex\ui\gear_minimipara_x_ca";
@@ -836,8 +836,8 @@ class CfgWeapons {
         model = "\hlc_wp_saw\mesh\mk48_des\Mk48.p3d";
         reloadaction = "HLC_GestureReloadM60";
         descriptionShort = "Light Machine Gun<br/>Caliber: 7.62mm";
-        drysound[] = {"\hlc_core\sound\empty_machineguns", 0.01, 1, 10};
-        reloadmagazinesound[] = {"\hlc_wp_saw\snd\mk48_reload", 0.5, 1, 20};
+        drysound[] = {"hlc_core\sound\empty_machineguns", 0.01, 1, 10};
+        reloadmagazinesound[] = {"hlc_wp_saw\snd\mk48_reload", 0.5, 1, 20};
         picture = "\hlc_wp_M60E4\tex\ui\gear_m60e4_x_ca";
         displayName = "FN Mk.48 Mod.0";
         discretedistance[] = {100, 200, 300, 400, 500,600,700,800};
@@ -908,8 +908,8 @@ class CfgWeapons {
         model = "\hlc_wp_saw\mesh\m249e2\m249e2.p3d";
         reloadaction = "HLC_GestureReloadM60";
         descriptionShort = "Light Machine Gun<br/>Caliber: 5.56mm";
-        drysound[] = {"\hlc_core\sound\empty_machineguns", 0.01, 1, 10};
-        reloadmagazinesound[] = {"\hlc_wp_saw\snd\saw_reload", 0.5, 1, 20};
+        drysound[] = {"hlc_core\sound\empty_machineguns", 0.01, 1, 10};
+        reloadmagazinesound[] = {"hlc_wp_saw\snd\saw_reload", 0.5, 1, 20};
         picture = "\hlc_wp_M60E4\tex\ui\gear_m60e4_x_ca";
         displayName = "M249E2";
         discretedistance[] = {100, 200, 300, 400, 500,600,700,800};

--- a/hlc_wp_sigamt/config.cpp
+++ b/hlc_wp_sigamt/config.cpp
@@ -619,7 +619,7 @@ class CfgWeapons {
         handanim[] = { "OFP2_ManSkeleton", "hlc_wp_sigamt\anim\hand_stgw57.rtm" };
         modes[] = { "Single", "FullAuto", "single_close_optics1", "single_medium_optics1", "single_far_optics1", "fullauto_medium" };
         reloadmagazinesound[] = { "hlc_wp_sigamt\snd\sigamt_reload", 0.630957, 1, 35 };
-        changeFiremodeSound[] = { "\hlc_wp_sigamt\snd\amtswitch", 1, 1, 8 };
+        changeFiremodeSound[] = { "hlc_wp_sigamt\snd\amtswitch", 1, 1, 8 };
         soundbullet[] = { "bullet1", 0.083, "bullet2", 0.083, "bullet3", 0.083, "bullet4", 0.083, "bullet5", 0.083, "bullet6", 0.083, "bullet7", 0.083, "bullet8", 0.083, "bullet9", 0.083, "bullet10", 0.083, "bullet11", 0.083, "bullet12", 0.083 };
         UiPicture = "\A3\weapons_f\data\UI\icon_regular_CA.paa";
 

--- a/hlc_wp_springfield/config.cpp
+++ b/hlc_wp_springfield/config.cpp
@@ -437,8 +437,8 @@ class CfgWeapons {
 		aiDispersionCoefY = 10;
 		aiDispersionCoefX = 8;
 
-		drysound[] = { "\hlc_core\sound\empty_machineguns", 1, 1, 10 };
-		reloadmagazinesound[] = { "\hlc_core\sound\empty_machineguns", 0.5, 1,10 };
+		drysound[] = { "hlc_core\sound\empty_machineguns", 1, 1, 10 };
+		reloadmagazinesound[] = { "hlc_core\sound\empty_machineguns", 0.5, 1,10 };
 	};
 
 
@@ -481,8 +481,8 @@ class CfgWeapons {
 		model = "\hlc_wp_springfield\mesh\1903A1fUnertl\1903A1.p3d";
 		reloadaction = "HLC_GestureReloadM1903A1_UN";
 		descriptionShort = "Springfield M1903A1 <br/>Sniper Rifle<br/>Caliber: .30-06";
-		drysound[] = { "\hlc_wp_springfield\snd\1903A1_dryfire", 1, 1, 10 };
-		reloadmagazinesound[] = { "\hlc_wp_springfield\snd\1903A1Unertl_reload", 0.8, 1, 20 };
+		drysound[] = { "hlc_wp_springfield\snd\1903A1_dryfire", 1, 1, 10 };
+		reloadmagazinesound[] = { "hlc_wp_springfield\snd\1903A1Unertl_reload", 0.8, 1, 20 };
 		modeloptics[] = { "\hlc_wp_springfield\mesh\1903A1Unertl\fine_reticle" };
 		inertia = 0.51;
         __DEXTERITY(5.1, 0);
@@ -582,7 +582,7 @@ class CfgWeapons {
 		model = "\hlc_wp_springfield\mesh\1903A1\1903A1.p3d";
 		reloadaction = "HLC_GestureReloadM1903A1";
 		descriptionShort = "Springfield M1903A1<br/>Infantry Rifle<br/>Caliber: .30-06";
-		drysound[] = { "\hlc_wp_springfield\snd\1903A1_dryfire", 1, 1, 10 };
+		drysound[] = { "hlc_wp_springfield\snd\1903A1_dryfire", 1, 1, 10 };
 		reloadmagazinesound[] = { "\hlc_wp_springfield\snd\1903A1_reload_noscope", 0.8, 1, 20 };
 		inertia = 0.43;
         __DEXTERITY(4.43, 0);


### PR DESCRIPTION
…eSound

As per BI's configs, no leading slashes on these, some of them cause RPT spam in MP when misconfigured.

```c++
drySound[] = {"A3\Sounds_F\arsenal\weapons\Rifles\MX\dry_Mx",0.562341,1,10};
reloadMagazineSound[] = {"A3\Sounds_F\arsenal\weapons\Rifles\MX\Reload_MX",1,1,10};
changeFiremodeSound[] = {"A3\Sounds_F\arsenal\weapons\Rifles\MX\firemode_Mx",0.177828,1,5};
```

