### PR TITLE
cba weapon animations

### DIFF
--- a/hlc_wp_fhAWC/config.cpp
+++ b/hlc_wp_fhAWC/config.cpp
@@ -476,14 +476,15 @@ class CfgWeapons {
         deployedPivot = "deploypoint";       /// what point should be used to be on surface while unfolded
         hasBipod = false;          /// a weapon with bipod obviously has a bipod
         magazineReloadSwitchPhase = 0.5;
-        class bg_weaponparameters {
-            class onFired_Action {
-                HandAction = "HLC_GestureRechamberAWM";
-                Actiondelay = 0.02;
-                Sound = "hlc_bolt_AWM";
-                Sound_Location = "RightHandMiddle1";
-                hasOptic = false;
-            };
+        class EventHandlers {
+            fired = "_this call CBA_fnc_weaponEvents";
+        };
+        class CBA_weaponEvents {
+            handAction = "HLC_GestureRechamberAWM";
+            sound = "hlc_bolt_AWM";
+            soundLocation = "RightHandMiddle1";
+            delay = 0.02;
+            onEmpty = 0;
         };
         cursor = "srifle";
         cursorAim = "EmptyCursor";
@@ -572,14 +573,15 @@ class CfgWeapons {
         magazineReloadSwitchPhase = 0.5;
         hiddenSelections[] = { "camo", "camo2", "Camo3" };
         hiddenSelectionsTextures[] = { "\hlc_wp_fhAWC\tex\awcstock_OD_co.paa","\hlc_wp_fhAWC\tex\AWC_Scope_co.paa","\hlc_wp_fhAWC\tex\Magnumbits_ca.paa" };
-        class bg_weaponparameters {
-            class onFired_Action {
-                HandAction = "HLC_GestureRechamberAWM";
-                Actiondelay = 0.02;
-                Sound = "hlc_bolt_AWM";
-                Sound_Location = "RightHandMiddle1";
-                hasOptic = false;
-            };
+        class EventHandlers {
+            fired = "_this call CBA_fnc_weaponEvents";
+        };
+        class CBA_weaponEvents {
+            handAction = "HLC_GestureRechamberAWM";
+            sound = "hlc_bolt_AWM";
+            soundLocation = "RightHandMiddle1";
+            delay = 0.02;
+            onEmpty = 0;
         };
         cursor = "srifle";
         cursorAim = "EmptyCursor";

--- a/hlc_wp_springfield/config.cpp
+++ b/hlc_wp_springfield/config.cpp
@@ -461,20 +461,19 @@ class CfgWeapons {
 		deployedPivot = "deploypoint";       /// what point should be used to be on surface while unfolded
 		hasBipod = false;          /// a weapon with bipod obviously has a bipod
 		magazineReloadSwitchPhase = 0.35;
-		class bg_weaponparameters
+		class EventHandlers
 		{
-
-			class onFired_Action
-			{
-				HandAction = "HLC_GestureRechamberM1903A1_UN";
-				Actiondelay = 0.02;
-				Sound = "hlc_bolt_1903";
-				Sound_Location = "RightHandMiddle1";
-				hasOptic = true;
-			};
-
-
-
+			fired = "_this call CBA_fnc_weaponEvents";
+		};
+		class CBA_weaponEvents
+		{
+			handAction = "HLC_GestureRechamberM1903A1_UN";
+			sound = "hlc_bolt_1903";
+			soundLocation = "RightHandMiddle1";
+			delay = 0.02;
+			onEmpty = 0;
+			soundEmpty = "";
+			soundLocationEmpty = "";
 		};
 		cursor = "srifle";
 		cursorAim = "EmptyCursor";

--- a/hlc_wp_springfield/config.cpp
+++ b/hlc_wp_springfield/config.cpp
@@ -564,18 +564,17 @@ class CfgWeapons {
 		deployedPivot = "deploypoint";       /// what point should be used to be on surface while unfolded
 		hasBipod = false;          /// a weapon with bipod obviously has a bipod
 		magazineReloadSwitchPhase = 0.5625;
-		class bg_weaponparameters
+		class EventHandlers
 		{
-
-			class onFired_Action
-			{
-				HandAction = "HLC_GestureRechamberM1903A1_UN";
-				Actiondelay = 0.02;
-				Sound = "hlc_bolt_1903";
-				Sound_Location = "RightHandMiddle1";
-				hasOptic = false;
-			};
-
+			fired = "_this call CBA_fnc_weaponEvents";
+		};
+		class CBA_weaponEvents
+		{
+			handAction = "HLC_GestureRechamberM1903A1_UN";
+			sound = "hlc_bolt_1903";
+			soundLocation = "RightHandMiddle1";
+			delay = 0.02;
+			onEmpty = 0;
 		};
 		cursor = "srifle";
 		cursorAim = "EmptyCursor";
@@ -617,18 +616,5 @@ class CfgWeapons {
 		displayName = "M1903A1 'Guthrie'";
 		model = "\hlc_wp_springfield\mesh\1903A1\1903A1_TMKB.p3d";
 		descriptionShort = "Seize the time,and storm the tower<br/>and come correct with maximum firepower";
-		class bg_weaponparameters
-		{
-
-			class onFired_Action
-			{
-				HandAction = "HLC_GestureRechamberM1903A1_UN";
-				Actiondelay = 0.02;
-				Sound = "hlc_bolt_1903";
-				Sound_Location = "RightHandMiddle1";
-				hasOptic = false;
-			};
-
-		};
 	};
 };

--- a/hlc_wp_springfield/config.cpp
+++ b/hlc_wp_springfield/config.cpp
@@ -472,6 +472,7 @@ class CfgWeapons {
 			soundLocation = "RightHandMiddle1";
 			delay = 0.02;
 			onEmpty = 0;
+			hasOptic = 1;
 			soundEmpty = "";
 			soundLocationEmpty = "";
 		};


### PR DESCRIPTION
see: https://github.com/CBATeam/CBA_A3/pull/829

`hlc_rifle_M1903A1OMR` inherits it from `hlc_rifle_M1903A1`, so no need to duplicate the entries.

For testing purposes.

I removed the `bg_weaponparameters` to avoid clashes.