### PR TITLE
Add simple zeroing to G36 irons

### DIFF
--- a/hlc_wp_g36/config.cpp
+++ b/hlc_wp_g36/config.cpp
@@ -1,4 +1,4 @@
-// NOTE TO  FUTURE ME - 
+// NOTE TO  FUTURE ME -
 //G36 Rifle-length cycle - 0.093
 //Carbine = 0.88
 //Compact - 0.82
@@ -63,7 +63,7 @@ class niarms_G36_OpticSlot: asdg_OpticRail {
     };
 };
 
-class CfgVehicles { 
+class CfgVehicles {
     dlc = "Niarms_G36";
     class NATO_Box_Base;
     class HLC_G36_ammobox : NATO_Box_Base {
@@ -681,7 +681,7 @@ class CfgWeapons {
             hasBipod = true;			/// bipod obviously has a bipod
             mass = 10;			/// what is the mass of the object
             soundBipodDown[] = { "A3\Sounds_F_Mark\arsenal\sfx\bipods\Bipod_BLU_down", db - 3, 1, 20 };	/// what sound should be played during unfolding
-            soundBipodUp[] = { "A3\Sounds_F_Mark\arsenal\sfx\bipods\Bipod_BLU_up", db - 3, 1, 20 };		/// what sound should be played during folding			
+            soundBipodUp[] = { "A3\Sounds_F_Mark\arsenal\sfx\bipods\Bipod_BLU_up", db - 3, 1, 20 };		/// what sound should be played during folding
         };
         inertia = 0.2;						/// how much does the bipod add to inertia of the weapon
     };
@@ -851,10 +851,10 @@ class CfgWeapons {
             __AI_ROF_RIFLE_SMALL_HSCOPE_SINGLE;
         };
         class AI_Burst_close : FullAuto {
-            
-                showToPlayer = 0; 
+
+                showToPlayer = 0;
                 aiBurstTerminable = 1;
-                burst = 4; 
+                burst = 4;
                 __AI_ROF_RIFLE_SMALL_CLOSE_BURST; \
         };
     };
@@ -1260,7 +1260,7 @@ class CfgWeapons {
             showToPlayer = 0;
             aiBurstTerminable = 1;
             burst = 4;
-            __AI_ROF_RIFLE_SMALL_CLOSE_BURST; 
+            __AI_ROF_RIFLE_SMALL_CLOSE_BURST;
         };
         class __MAGSWITCHCLASS {
             hlc_100rnd_556x45_EPR_G36 = "hlc_rifle_G36c_CMAG";
@@ -1402,7 +1402,9 @@ class CfgWeapons {
             class Kolimator {
                 cameradir = "";
                 distancezoommax = 100;
-                distancezoommin = 100;
+                distancezoommin = 500;
+                discreteDistance[] = {100, 200, 300, 400, 500};
+                discreteDistanceInitIndex = 1;
                 memorypointcamera = "eye";
                 opticsdisableperipherialvision = 0;
                 opticsflare = 0;
@@ -1452,7 +1454,9 @@ class CfgWeapons {
             class Kolimator {
                 cameradir = "";
                 distancezoommax = 100;
-                distancezoommin = 100;
+                distancezoommin = 500;
+                discreteDistance[] = {100, 200, 300, 400, 500};
+                discreteDistanceInitIndex = 1;
                 memorypointcamera = "eye";
                 opticsdisableperipherialvision = 0;
                 opticsflare = 0;
@@ -1692,7 +1696,7 @@ class CfgWeapons {
         model = "hlc_wp_g36\mesh\G36Tactical\G36C_CMag.p3d";
         picture = "\hlc_wp_g36\tex\ui\gear_g36ctac-cmag_ca.paa";
     };
-    ///CASELESS 
+    ///CASELESS
 
     class hlc_rifle_G36MLIC : hlc_G36_base {
         dlc = "Niarms_G36";


### PR DESCRIPTION
This PR will add some simple zeroing to the iron sights for the full rifle G36es. I used the range values that the G36C(V) uses.