### PR TITLE
Alt-Reload Script

### DIFF
--- a/hlc_core/CfgEventHandlers.hpp
+++ b/hlc_core/CfgEventHandlers.hpp
@@ -9,6 +9,9 @@ class Extended_Reloaded_EventHandlers {
         class nia_core {
             clientReloaded = "_this call Niarms_fnc_magSwitch";
         };
+        class nia_altReloads {
+            clientReloaded = "_this call NIArms_altReloads_fnc_afterReload;";
+        };
     };
 };
 

--- a/hlc_core/CfgFunctions.hpp
+++ b/hlc_core/CfgFunctions.hpp
@@ -18,4 +18,15 @@ class CfgFunctions {
             };
         };
     };
+    class NIArms_altReloads {
+      class functions {
+        file = "\hlc_core\functions\alt_reloads";
+        class afterReload {};
+        class getAttachments {};
+        class onReload {};
+        class perFrame {};
+        class postInit {};
+        class setAttachments {};
+      };
+    };
 };

--- a/hlc_core/RscIngameUI.hpp
+++ b/hlc_core/RscIngameUI.hpp
@@ -5,7 +5,7 @@ class RscInGameUI
 
   class Niarms_Rsc_AltReload_Zeroing: RscWeaponZeroing
   {
-    idd = 9640
+    idd = 9640;
     onLoad="['onLoad',_this,'RscUnitInfo','IGUI'] call (uinamespace getvariable 'BIS_fnc_initDisplay'); _this call Niarms_altReloads_fnc_postInit;";
   };
 };

--- a/hlc_core/RscIngameUI.hpp
+++ b/hlc_core/RscIngameUI.hpp
@@ -1,0 +1,10 @@
+class RscInGameUI
+{
+  class RscUnitInfoSoldier;
+  class RscWeaponZeroing;
+
+  class Niarms_Rsc_AltReload_Zeroing: RscWeaponZeroing
+  {
+    onLoad="['onLoad',_this,'RscUnitInfo','IGUI'] call (uinamespace getvariable 'BIS_fnc_initDisplay'); _this call Niarms_altReloads_fnc_postInit;";
+  };
+};

--- a/hlc_core/RscIngameUI.hpp
+++ b/hlc_core/RscIngameUI.hpp
@@ -5,6 +5,7 @@ class RscInGameUI
 
   class Niarms_Rsc_AltReload_Zeroing: RscWeaponZeroing
   {
+    idd = 9640
     onLoad="['onLoad',_this,'RscUnitInfo','IGUI'] call (uinamespace getvariable 'BIS_fnc_initDisplay'); _this call Niarms_altReloads_fnc_postInit;";
   };
 };

--- a/hlc_core/config.cpp
+++ b/hlc_core/config.cpp
@@ -14,14 +14,15 @@ class CfgPatches {
         version = "1.5";
     };
 };
-#include "CfgAmmo.hpp"  
-#include "CfgMagazines.hpp"  
+#include "CfgAmmo.hpp"
+#include "CfgMagazines.hpp"
 #include "CfgFunctions.hpp"
 #include "CfgEventhandlers.hpp"
 #include "cfgsoundshaders.hpp"
 #include "cfgsoundset.hpp"
 #include "Particles.hpp"
 #include "CfgMagazineWells.hpp"
+#include "RscInGameUI.hpp"
 
 class asdg_MuzzleSlot;
 class asdg_MuzzleSlot_762 : asdg_MuzzleSlot {
@@ -107,7 +108,7 @@ class nia_rifle_grips_slot : nia_rifle_gripod_slot
         hlc_grip_PMVFG = 1;
     };
 };
-class nia_rifle_bipodsgrips_slot :asdg_UnderSlot 
+class nia_rifle_bipodsgrips_slot :asdg_UnderSlot
 {
 };
 class PointerSlot;
@@ -118,7 +119,7 @@ class nia_charms_slot : PointerSlot
     linkProxy = "\hlc_core\mesh\nia_charm_proxy";
     class compatibleItems
     {
-        //The commented out ones are special patron ones. While I can't stop anyone with the wherewithall to compile a PBO from just uncommenting them and whatever, you know, keep it to yourself. 
+        //The commented out ones are special patron ones. While I can't stop anyone with the wherewithall to compile a PBO from just uncommenting them and whatever, you know, keep it to yourself.
         //HLC_Charm_Eurojank = 1;
         //HLC_Charm_NIArmsbacker = 1;
         //HLC_Charm_NIArmsbacker_dirty = 1;
@@ -159,7 +160,7 @@ class CfgDistanceFilters
     };
 };
 /*
-Scripting notes- 
+Scripting notes-
 
 
 Weaponslotsinfo MASS is approximate to CENTAGRAMS... that is to say a mass of 7 is a mass of about 700 grams. Take consideration of this
@@ -194,16 +195,16 @@ class CfgMovesBasic
      class DefaultDie;
      class ManActions
      {
-         FHQ_GestureReloadACR = "FHQ_GestureReloadACR";    
+         FHQ_GestureReloadACR = "FHQ_GestureReloadACR";
      };
-    
+
     class Actions {
         class NoActions : ManActions {
             FHQ_GestureReloadACR[] = {"FHQ_GestureReloadACR", "Gesture"};
         };
     };
 };
- 
+
 class CfgGesturesMale
 {
     class Default;
@@ -952,7 +953,7 @@ class CfgGesturesMale {
         };
         class HLC_GestureReloadG3SG1_Context : HLC_GestureReloadG3SG1 {
             mask = "handsWeapon_context";
-        };         
+        };
         class HLC_GestureReloadHK53 : Default {
             file="hlc_core\animation\gesture\reload_hk53_standing.rtm";
             speed=0.16666666666666666666666666666667;
@@ -1885,7 +1886,7 @@ Speed  = speed at 200m
 
 class CfgWeapons
 
-{ 
+{
     #include "cfg_acc_muzzle.hpp"
     #include "cfg_acc_sidemount.hpp"
     #include "cfg_acc_scope.hpp"
@@ -1969,4 +1970,3 @@ class CfgWeapons
         magazines[] += { __556STANAG_MAGS };
     };
 };
-

--- a/hlc_core/functions/alt_reloads/README.md
+++ b/hlc_core/functions/alt_reloads/README.md
@@ -22,6 +22,8 @@ class NIArms_Alt_Reloads //The main class, without this it won't work
   };
 };
 ```
+If no conditions return true, it will simply default to engine reloading!
+
 Keep the reload classes simple and identical to their parent class.
 Example:
 ```cpp

--- a/hlc_core/functions/alt_reloads/README.md
+++ b/hlc_core/functions/alt_reloads/README.md
@@ -1,0 +1,36 @@
+# NIArms
+
+Alternative reloads allows you to have different model.cfg and hand gesture reload animations for a single weapon.
+To achieve this you need to make multiple copies of the weapon depending on how many animation variations you want.
+Once this is done you set up class names for them as you would any other weapon (keep them scope 1 obviously).
+
+Inside the 'real' weapon config you need to define some classes, example:
+```cpp
+class NIArms_Alt_Reloads //The main class, without this it won't work
+{
+  class LIB_LeeEnfield_No4 //A weapon class name, the class name to be used if the condition below is true
+  {
+    condition = "(%1 == 0 || %1 == 10)"; //Condition, %1 is the ammo in the currently loaded magazine, so in this example if the weapon is empty or full, use the default class, which will skip the system entirely.
+  };
+  class LIB_LeeEnfield_No4_altReload1 // Each condition is checked in order, and the first one to return true will be used, but it's good practice to keep it so only one is true.
+  {
+    condition = "(%1 > 6)";
+  };
+  class LIB_LeeEnfield_No4_altReload2
+  {
+    condition = "((%1 <= 6) && (%1 > 4))";
+  };
+};
+```
+Keep the reload classes simple and identical to their parent class.
+Example:
+```cpp
+class LIB_LeeEnfield_No4_altReload1: LIB_LeeEnfield_No4
+{
+  scope = 1;
+  baseweapon = "LIB_LeeEnfield_No4"; //This ensures stuff like arsenal hides it
+  reloadAction = "LIB_GestureReload_Common_sniper";
+  model = "\WW2\Assets_m\Weapons\Rifles_m\DD_Enfield_No4_altReload1.p3d";
+  reloadMagazineSound[] = {"\WW2\Assets_s\Weapons\Rifles_s\BoltAction\Reload_sniper.wss",1,1,10};
+};
+```

--- a/hlc_core/functions/alt_reloads/README.md
+++ b/hlc_core/functions/alt_reloads/README.md
@@ -6,6 +6,7 @@ Once this is done you set up class names for them as you would any other weapon 
 
 Inside the 'real' weapon config you need to define some classes, example:
 ```cpp
+weaponInfoType = "Niarms_Rsc_AltReload_Zeroing"; //This needs to be set in the main weapon, it runs the per frame handler and stops it when its not needed.
 class NIArms_Alt_Reloads //The main class, without this it won't work
 {
   class LIB_LeeEnfield_No4 //A weapon class name, the class name to be used if the condition below is true

--- a/hlc_core/functions/alt_reloads/fn_afterReload.sqf
+++ b/hlc_core/functions/alt_reloads/fn_afterReload.sqf
@@ -1,0 +1,77 @@
+/*
+	Author: Kerc
+
+	Description:
+        Reloaded EH, switches the weapon back to the original after the reload has been completed.
+
+  Parameters:
+		entity: Object - unit or vehicle to which EH is assigned
+		weapon: String - weapon that got reloaded
+		muzzle: String - weapons muzzle that got reloaded
+		newMagazine: Array - new magazine info in format [magazineClass, ammoCount, magazineID, magazineCreator], where:
+		magazineClass: String - class name of the magazine
+		ammoCount: Number - amount of ammo in magazine
+		magazineID: Number - global magazine id
+		magazineCreator: Number - owner of the magazine creator
+		(oldMagazine): Array - old magazine that was in the muzzle before. Could be Nothing if muzzle was empty prior to reload event. Format is the same as for the newMagazine.
+	Returns:
+        Nothing
+
+
+    Example:
+        _this call NIArms_altReloads_fnc_afterReload;
+*/
+params [
+	"_unit",
+	"_weapon",
+	"",
+	"_newMagazine",
+	""
+];
+
+if (!isNil "NIArms_altReloads_tempReloadWeapon" &&  {((_weapon) == NIArms_altReloads_tempReloadWeapon)}) then
+{
+	_newMagazine params ["_mag","_ammo"];
+	private _attachments = [_unit,NIArms_altReloads_tempReloadWeapon] call NIArms_altReloads_fnc_getAttachments;
+	_unit removeWeapon _weapon;
+	private ["_tempMag","_tempAmmo"];
+	_unit addWeapon NIArms_altReloads_previousWeapon;
+	switch (NIArms_altReloads_previousWeapon) do
+	{
+		case (primaryWeapon _unit):
+		{
+			_tempMag = (primaryweaponMagazine _unit select 0);
+ 			_tempAmmo = _unit ammo NIArms_altReloads_previousWeapon;
+			_unit removePrimaryWeaponItem (currentMagazine _unit);
+			_unit addprimaryweaponitem _mag;
+		};
+		case (secondaryWeapon _unit):
+		{
+			_tempMag = (secondaryWeaponMagazine _unit select 0);
+			_tempAmmo = _unit ammo NIArms_altReloads_previousWeapon;
+			_unit removesecondaryWeaponItem (currentMagazine _unit);
+			_unit addsecondaryweaponitem _mag;
+		};
+		case (handgunweapon _unit):
+		{
+			_tempMag = (handgunMagazine _unit select 0);
+			_tempAmmo = _unit ammo NIArms_altReloads_previousWeapon;
+			_unit removeHandgunItem (currentMagazine _unit);
+			_unit addhandgunitem _mag;
+		};
+	};
+
+
+
+
+	[_unit,NIArms_altReloads_previousWeapon,_attachments] call NIArms_altReloads_fnc_setAttachments;
+	_unit setWeaponReloadingTime [_unit, NIArms_altReloads_previousWeapon, 0];
+	_unit selectWeapon NIArms_altReloads_previousWeapon;
+	_unit setammo [NIArms_altReloads_previousWeapon,_ammo];
+	_unit addmagazine [_tempMag,_tempAmmo];
+	NIArms_altReloads_isReloading = false;
+	NIArms_altReloads_tempReloadWeapon = nil;
+	NIArms_altReloads_previousWeapon = nil;
+	[_unit, NIArms_altReloads_previousWeapon, (_unit getVariable ["NIArms_altReloads_lastfireMode",""])] call CBA_fnc_selectWeapon;
+};
+NIArms_altReloads_isReloading = false;

--- a/hlc_core/functions/alt_reloads/fn_getAttachments.sqf
+++ b/hlc_core/functions/alt_reloads/fn_getAttachments.sqf
@@ -1,0 +1,44 @@
+/*
+	Author: Kerc, original by Laxemann
+
+	Description:
+        Gets currently fitted attachments for weapon
+
+  Parameters:
+        unit, weapon class
+
+	Returns:
+        Nothing
+
+
+    Example:
+        [_unit,_fakeWeapon] call NIArms_altReloads_fnc_getAttachments;
+*/
+params [
+	"_unit",
+	"_weapon"
+];
+private _attachments = [];
+
+if (_weapon == primaryWeapon _unit) then {
+	(primaryWeaponItems _unit) params [
+		"_silencer",
+		"_rail",
+		"_optics",
+		"_bipod"
+	];
+	_attachments = [_silencer,_rail,_optics,_bipod];
+} else {
+	if (_weapon == handgunWeapon _unit) then {
+		(handgunItems _unit) params [
+			"_silencer",
+			"_rail",
+			"_optics",
+			"_bipod"
+		];
+		_attachments = [_silencer,_rail,_optics,_bipod];
+	};
+};
+
+// Return
+_attachments

--- a/hlc_core/functions/alt_reloads/fn_onReload.sqf
+++ b/hlc_core/functions/alt_reloads/fn_onReload.sqf
@@ -1,0 +1,132 @@
+/*
+	Author: Kerc
+
+	Description:
+        Fired when player presses reload button, handles playing different animations depending on amount of ammunition left in current magazine.
+
+  Parameters:
+        Doesn't need any, can be run from Reload EH but is broken, don't use it.
+	Returns:
+        Nothing
+
+
+    Example:
+        [] call NIArms_altReloads_fnc_onReload;
+*/
+params [["_unit",(player)], ["_weapon",(currentWeapon player)], ["_muzzle",(currentMuzzle player)], "_newMagazine", ["_oldMagazine",(currentMagazine player)]];
+private ["_oldAmmo","_oldMag"];
+if (NIArms_altReloads_isReloading) exitwith {};
+if (_oldMagazine isEqualType []) then
+{
+  _oldMag = _oldMagazine select 0;
+  _oldAmmo = _oldMagazine select 1;
+}
+else
+{
+  _oldAmmo = _unit ammo _weapon;
+  _oldMag  = _oldMagazine;
+};
+private _conditionAmmo = _oldAmmo;
+if (!isNil "_newMagazine" &&  {_newMagazine isEqualType []}) then
+{
+  if ((getText (configFile >> "CfgMagazines" >> _oldMag >> "ammo")) != (getText (configFile >> "CfgMagazines" >> (_newMagazine select 0) >> "ammo"))) exitwith {_conditionAmmo = (getNumber (configFile >> "CfgMagazines" >> _oldMag >> "count"));};
+}; //Switching ammo type, do full reload, might want to change this depending on magazine type/weapon
+
+private _fakeWeapon = _weapon;
+if !(isClass (configFile >> "CfgWeapons" >> _weapon >> "NIArms_Alt_Reloads")) exitwith {};
+
+
+
+{
+	private _condition = call compile format [(getText (_x >> "condition")),_conditionAmmo];
+	if (_condition) exitwith {_fakeWeapon = (configName _x);};
+} foreach ("true" configClasses (configFile >> "CfgWeapons" >> _weapon >> "NIArms_Alt_Reloads"));
+
+if (_fakeWeapon == _weapon) exitwith {};
+
+NIArms_altReloads_isReloading = true;
+private _magazinesOfWeaponType = getArray(configFile >> "CfgWeapons" >> _weapon >> "magazines");
+
+
+private _attachments 	= [_unit,_weapon] call NIArms_altReloads_fnc_getAttachments;
+
+private _fireMode = currentWeaponMode _unit;
+_unit setVariable ["NIArms_altReloads_lastfireMode",_fireMode];
+
+private _allMagazinesUnit = magazinesAmmoFull _unit;
+_allMagazinesUnit sort false;
+
+//We have to do this the old shitty way instead of 'add*weapon*item' as it seems to trigger the animation breaking, while having it autoload a magazine upon 'addweapon' does not
+_unit removeWeapon _weapon;
+{
+  _unit removeMagazines _x
+} forEach _magazinesOfWeaponType;
+_unit addmagazine [_oldMag,_oldammo];
+_unit addWeapon _fakeWeapon;
+
+
+
+
+
+[_unit,_fakeWeapon,_attachments] call NIArms_altReloads_fnc_setAttachments;
+_unit selectWeapon _fakeWeapon;
+_unit setWeaponReloadingTime [_unit, _fakeWeapon, 0];
+
+//Hacky work around inbound, brace for impact
+private ["_newMag","_newAmmo"];
+if (!isNil "_newMagazine" &&  {_newMagazine isEqualType []}) then
+{
+  _newMag  = _newMagazine select 0;
+  _newAmmo = _newMagazine select 1;
+}
+else
+{
+  {
+    	_x params ["_magazineClass","_magazineAmmoCount","_isMagazineLoaded"];
+      if (_magazineClass in _magazinesOfWeaponType && !_isMagazineLoaded) exitwith
+      {
+        _newMag  = _magazineClass;
+        _newAmmo = _magazineAmmoCount;
+        _allMagazinesUnit deleteat _foreachIndex;
+      };
+  } foreach _allMagazinesUnit
+};
+_unit addMagazine [_newMag,_newAmmo];
+private _indexNum = 0;
+{
+  if (_x isequalTo [_newMag,_newAmmo]) exitwith {_indexNum = _forEachIndex;};
+} foreach magazinesammo _unit;
+private _magazinesDetail = magazinesdetail _unit;
+private _string = (_magazinesDetail select _indexNum) splitString "[:/]";
+private _id = parseNumber(_string select 4);
+private _creator = parseNumber(_string select 5);
+_unit action ["loadmagazine",_unit, _unit, _creator, _id ,_fakeWeapon, _fakeWeapon];
+
+NIArms_altReloads_tempReloadWeapon = _fakeWeapon;
+NIArms_altReloads_previousWeapon = _weapon;
+
+
+private "_container";
+{
+	_x params ["_magazineClass","_magazineAmmoCount","_isMagazineLoaded","","_magazineContainer"];
+
+  if (!(_isMagazineLoaded)) then
+	{
+		//is magazine from old weapon, replace magazine
+		if (({_x == _magazineClass} count _magazinesOfWeaponType) > 0) then
+		{
+			_container = switch (_magazineContainer) do
+			{
+				case "Uniform":		{uniformContainer _unit};
+				case "Vest":		{vestContainer _unit};
+				case "Backpack":	{backpackContainer _unit};
+				default			{objNull};
+			};
+
+			if (!(isNull _container)) then
+			{
+				_container addMagazineAmmoCargo [_magazineClass,1,_magazineAmmoCount];
+			};
+		};
+	};
+} forEach _allMagazinesUnit;

--- a/hlc_core/functions/alt_reloads/fn_perFrame.sqf
+++ b/hlc_core/functions/alt_reloads/fn_perFrame.sqf
@@ -1,0 +1,20 @@
+/*
+	Author: Kerc, original by Laxemann
+
+	Description:
+        Perframe check for input
+
+  Parameters:
+        None
+	Returns:
+        Nothing
+
+
+    Example:
+        NIArms_altReloads_Handler = [NIArms_altReloads_fnc_perFrame,0] call CBA_fnc_addPerFrameHandler;
+*/
+if !(NIArms_altReloads_isReloading) then {
+	if (inputAction "reloadMagazine" > 0) then {
+		[] call NIArms_altReloads_fnc_onReload;
+	};
+};

--- a/hlc_core/functions/alt_reloads/fn_postInit.sqf
+++ b/hlc_core/functions/alt_reloads/fn_postInit.sqf
@@ -1,0 +1,44 @@
+/*
+	Author: Kerc
+
+	Description:
+        Initiates the per frame check for when the player presses their reload key/input
+
+  Parameters:
+        Display, run onLoad in ingameUi
+
+	Returns:
+        Nothing
+
+
+    Example:
+        onLoad="['onLoad',_this,'RscUnitInfo','IGUI'] call (uinamespace getvariable 'BIS_fnc_initDisplay'); _this call NIArms_altReloads_fnc_postInit;"
+*/
+NIArms_altReloads_isReloading = false;
+if (isDedicated) exitwith {};
+
+uiNameSpace setVariable ["NIArms_altReloads_Ui_Display",_this select 0];
+
+[]
+spawn
+{
+  disableSerialization;
+  private _display = uiNamespace getVariable "NIArms_altReloads_Ui_Display";
+  private _control = (_display displayCtrl 168);
+  if (isNil "NIArms_altReloads_Handler") then
+  {
+    NIArms_altReloads_Handler = [NIArms_altReloads_fnc_perFrame,0] call CBA_fnc_addPerFrameHandler; //CBA_fnc_addPerFrameHandler
+  };
+  waituntil {sleep 1; isNull _control};
+  [NIArms_altReloads_Handler] call CBA_fnc_RemovePerFrameHandler;
+  NIArms_altReloads_Handler = nil;
+  uiNameSpace setVariable ["NIArms_altReloads_Ui_Display",nil];
+};
+
+/* if !((productVersion select 2) >= 191) then
+{
+  [{
+  	call NIArms_altReloads_fnc_perFrame;
+  }, 0] call CBA_fnc_addPerFrameHandler;
+
+}; */

--- a/hlc_core/functions/alt_reloads/fn_setAttachments.sqf
+++ b/hlc_core/functions/alt_reloads/fn_setAttachments.sqf
@@ -1,0 +1,34 @@
+/*
+	Author: Kerc, original by Laxemann
+
+	Description:
+        Sets appropriate attachments for weapon
+
+  Parameters:
+        unit, weapon, attachments (array)
+
+	Returns:
+        Nothing
+
+
+    Example:
+        [_unit,_fakeWeapon,_attachments] call NIArms_altReloads_fnc_setAttachments;
+*/
+params [
+	"_unit",
+	"_weapon",
+	"_attachments" // Array!
+];
+
+
+if (_weapon == primaryWeapon _unit) then {
+	private _dummyArray = _attachments select {
+		_unit addPrimaryWeaponItem _x;
+		false;
+	};
+} else {
+	if (_weapon == handgunWeapon player) then {
+		_unit addHandgunItem _x;
+		false;
+	};
+};


### PR DESCRIPTION
Alternative reloads allows you to have different model.cfg and hand gesture reload animations for a single weapon. To achieve this you need to make multiple copies of the weapon depending on how many animation variations you want. Once this is done you set up class names for them as you would any other weapon (keep them scope 1 obviously).