### PR TITLE
Fix ACE_bulletLength on GP11 ammo classes

### DIFF
--- a/hlc_core/Cfgammo.hpp
+++ b/hlc_core/Cfgammo.hpp
@@ -1065,7 +1065,7 @@ class CfgAmmo {
         hit = 11.71;
         typicalSpeed = 750;
         ACE_caliber = 7.7724;
-        ACE_bulletLength = ‪35.0012‬;
+        ACE_bulletLength = 35.0012;
         ACE_bulletMass = 11.275;
         ACE_ammoTempMuzzleVelocityShifts[] = { -26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19 };
         ACE_ballisticCoefficients[] = { 0.505 };

--- a/hlc_core/Cfgammo.hpp
+++ b/hlc_core/Cfgammo.hpp
@@ -1107,7 +1107,7 @@ class CfgAmmo {
         hit = 9.7608273215;
         typicalSpeed = 910;
         ACE_caliber = 7.7724;
-        ACE_bulletLength = ‪35.0012‬;
+        ACE_bulletLength = 35.0012;
         ACE_bulletMass = 11.275;
         ACE_ammoTempMuzzleVelocityShifts[] = { -26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19 };
         ACE_ballisticCoefficients[] = { 0.514 };


### PR DESCRIPTION
Current code on those two lines contains some control characters, maybe from Spartan's google doc. They don't get displayed on the GitHub file _viewer_, and the _editor_ only does some minor syntax highlighting. But Arma includes them in the config value, causing an .rpt error every time you open the ACE rangecard for these.

Thanks to brainslush for putting me on the right track.