### PR TITLE
Don't overwrite BI mag lists in magWells

### DIFF
--- a/hlc_core/CfgMagazineWells.hpp
+++ b/hlc_core/CfgMagazineWells.hpp
@@ -117,13 +117,6 @@ class CfgMagazineWells
             "hlc_30rnd_556x45_MDim_EMAG",
             "hlc_30rnd_556x45_TDim_EMAG"
         };
-        BI_Magazines[] =
-        {
-            "30Rnd_556x45_Stanag",
-            "30Rnd_556x45_Stanag_Tracer_Red",
-            "30Rnd_556x45_Stanag_Tracer_Green",
-            "30Rnd_556x45_Stanag_Tracer_Yellow"
-        };
     };
     /*class M249_556x49
     {
@@ -181,42 +174,4 @@ class CfgMagazineWells
         };
     };*/
     class NIA_STANAG_556x45 :STANAG_556x45 {};
-    class UGL_40x36
-    {
-        BI_Magazines[] =
-        {
-            "1Rnd_HE_Grenade_shell",
-            "UGL_FlareWhite_F",
-            "UGL_FlareGreen_F",
-            "UGL_FlareRed_F",
-            "UGL_FlareYellow_F",
-            "UGL_FlareCIR_F",
-            "1Rnd_Smoke_Grenade_shell",
-            "1Rnd_SmokeRed_Grenade_shell",
-            "1Rnd_SmokeGreen_Grenade_shell",
-            "1Rnd_SmokeYellow_Grenade_shell",
-            "1Rnd_SmokePurple_Grenade_shell",
-            "1Rnd_SmokeBlue_Grenade_shell",
-            "1Rnd_SmokeOrange_Grenade_shell"
-        };
-    };
-    class 3UGL_40x36
-    {
-        BI_Magazines[] =
-        {
-            "3Rnd_HE_Grenade_shell",
-            "3Rnd_UGL_FlareWhite_F",
-            "3Rnd_UGL_FlareGreen_F",
-            "3Rnd_UGL_FlareRed_F",
-            "3Rnd_UGL_FlareYellow_F",
-            "3Rnd_UGL_FlareCIR_F",
-            "3Rnd_Smoke_Grenade_shell",
-            "3Rnd_SmokeRed_Grenade_shell",
-            "3Rnd_SmokeGreen_Grenade_shell",
-            "3Rnd_SmokeYellow_Grenade_shell",
-            "3Rnd_SmokePurple_Grenade_shell",
-            "3Rnd_SmokeBlue_Grenade_shell",
-            "3Rnd_SmokeOrange_Grenade_shell"
-        };
-    };
 };


### PR DESCRIPTION
When merged, this PR will:
- Remove code overwriting BI's own magazine lists in `STANAG_556x45`, `UGL_40x36` and `3UGL_40x36` that they have been maintaining themselves for a few patches now; fixes behaviour reported in [this post](https://forums.bohemia.net/forums/topic/190455-niarms-release-thread/?page=52&tab=comments#comment-3385960).