### PR TITLE
Fix double white in VOG names; some German translation

### DIFF
--- a/hlc_core/Stringtable.xml
+++ b/hlc_core/Stringtable.xml
@@ -2010,7 +2010,7 @@
         <Polish>7.62mm Tracer 30Rnd 6L10 AK Magazine</Polish>
         <Portuguese>7.62mm Tracer 30Rnd 6L10 AK Magazine</Portuguese>
         <Russian>7.62mm Tracer 30Rnd 6L10 AK Magazine</Russian>
-        <German>7.62mm Tracer 30Rnd 6L10 AK Magazine</German>
+        <German>7.62mm Leuchtspur 30 Schuss 6L10 AK-Magazin</German>
         <Japanese>7.62mm 曳光弾 30発入り 6L10 AK マガジン</Japanese>
         <Korean>7.62mm Tracer 30Rnd 6L10 AK Magazine</Korean>
         <Chinesesimp>7.62mm Tracer 30Rnd 6L10 AK Magazine</Chinesesimp>
@@ -2025,7 +2025,7 @@
         <Polish>7.62mm FMJ 30Rnd 6L10 AK Magazine (Tracers Every 3)</Polish>
         <Portuguese>7.62mm FMJ 30Rnd 6L10 AK Magazine (Tracers Every 3)</Portuguese>
         <Russian>7.62mm FMJ 30Rnd 6L10 AK Magazine (Tracers Every 3)</Russian>
-        <German>7.62mm FMJ 30Rnd 6L10 AK Magazine (Tracers Every 3)</German>
+        <German>7.62mm FMJ 30 Schuss 6L10 AK-Magazin (Leuchtspur alle 3)</German>
         <Japanese>7.62mm FMJ 30発入り 6L10 AK マガジン (3発毎に曳光弾)</Japanese>
         <Korean>7.62mm FMJ 30Rnd 6L10 AK Magazine (Tracers Every 3)</Korean>
         <Chinesesimp>7.62mm FMJ 30Rnd 6L10 AK Magazine (Tracers Every 3)</Chinesesimp>
@@ -2040,7 +2040,7 @@
         <Polish>7.62mm AP 30Rnd 6L10 AK Magazine</Polish>
         <Portuguese>7.62mm AP 30Rnd 6L10 AK Magazine</Portuguese>
         <Russian>7.62mm AP 30Rnd 6L10 AK Magazine</Russian>
-        <German>7.62mm AP 30Rnd 6L10 AK Magazine</German>
+        <German>7.62mm AP 30 Schuss 6L10 AK-Magazin</German>
         <Japanese>7.62mm AP 30発入り 6L10 AK マガジン</Japanese>
         <Korean>7.62mm AP 30Rnd 6L10 AK Magazine</Korean>
         <Chinesesimp>7.62mm AP 30Rnd 6L10 AK Magazine</Chinesesimp>
@@ -2055,7 +2055,7 @@
         <Polish>7.62mm Subsonic 30Rnd 6L10 AK Magazine</Polish>
         <Portuguese>7.62mm Subsonic 30Rnd 6L10 AK Magazine</Portuguese>
         <Russian>7.62mm Subsonic 30Rnd 6L10 AK Magazine</Russian>
-        <German>7.62mm Subsonic 30Rnd 6L10 AK Magazine</German>
+        <German>7.62mm Unterschall 30 Schuss 6L10 AK-Magazin</German>
         <Japanese>7.62mm 亜音速 30発入り 6L10 AK マガジン</Japanese>
         <Korean>7.62mm Subsonic 30Rnd 6L10 AK Magazine</Korean>
         <Chinesesimp>7.62mm Subsonic 30Rnd 6L10 AK Magazine</Chinesesimp>
@@ -2070,7 +2070,7 @@
         <Polish>7.62mm FMJ 30Rnd Rk62 Magazine</Polish>
         <Portuguese>7.62mm FMJ 30Rnd Rk62 Magazine</Portuguese>
         <Russian>7.62mm FMJ 30Rnd Rk62 Magazine</Russian>
-        <German>7.62mm FMJ 30Rnd Rk62 Magazine</German>
+        <German>7.62mm FMJ 30 Schuss Rk62-Magazin</German>
         <Japanese>7.62mm FMJ 30発入り Rk62 マガジン</Japanese>
         <Korean>7.62mm FMJ 30Rnd Rk62 Magazine</Korean>
         <Chinesesimp>7.62mm FMJ 30Rnd Rk62 Magazine</Chinesesimp>
@@ -2085,7 +2085,7 @@
         <Polish>7.62mm Tracer 30Rnd Rk62 Magazine</Polish>
         <Portuguese>7.62mm Tracer 30Rnd Rk62 Magazine</Portuguese>
         <Russian>7.62mm Tracer 30Rnd Rk62 Magazine</Russian>
-        <German>7.62mm Tracer 30Rnd Rk62 Magazine</German>
+        <German>7.62mm Leuchtspur 30 Schuss Rk62-Magazin</German>
         <Japanese>7.62mm 曳光弾 30発入り Rk62 マガジン</Japanese>
         <Korean>7.62mm Tracer 30Rnd Rk62 Magazine</Korean>
         <Chinesesimp>7.62mm Tracer 30Rnd Rk62 Magazine</Chinesesimp>
@@ -2100,7 +2100,7 @@
         <Polish>7.62mm FMJ 30Rnd Rk62 Magazine (Tracers Every 3)</Polish>
         <Portuguese>7.62mm FMJ 30Rnd Rk62 Magazine (Tracers Every 3)</Portuguese>
         <Russian>7.62mm FMJ 30Rnd Rk62 Magazine (Tracers Every 3)</Russian>
-        <German>7.62mm FMJ 30Rnd Rk62 Magazine (Tracers Every 3)</German>
+        <German>7.62mm FMJ 30 Schuss Rk62-Magazin (Leuchtspur alle 3)</German>
         <Japanese>7.62mm FMJ 30発入り Rk62 マガジン (3発毎に曳光弾)</Japanese>
         <Korean>7.62mm FMJ 30Rnd Rk62 Magazine (Tracers Every 3)</Korean>
         <Chinesesimp>7.62mm FMJ 30Rnd Rk62 Magazine (Tracers Every 3)</Chinesesimp>
@@ -2115,7 +2115,7 @@
         <Polish>7.62mm AP 30Rnd Rk62 Magazine</Polish>
         <Portuguese>7.62mm AP 30Rnd Rk62 Magazine</Portuguese>
         <Russian>7.62mm AP 30Rnd Rk62 Magazine</Russian>
-        <German>7.62mm AP 30Rnd Rk62 Magazine</German>
+        <German>7.62mm AP 30 Schuss Rk62-Magazin</German>
         <Japanese>7.62mm AP 30発入り Rk62 マガジン</Japanese>
         <Korean>7.62mm AP 30Rnd Rk62 Magazine</Korean>
         <Chinesesimp>7.62mm AP 30Rnd Rk62 Magazine</Chinesesimp>
@@ -2130,7 +2130,7 @@
         <Polish>7.62mm Subsonic 30Rnd Rk62 Magazine</Polish>
         <Portuguese>7.62mm Subsonic 30Rnd Rk62 Magazine</Portuguese>
         <Russian>7.62mm Subsonic 30Rnd Rk62 Magazine</Russian>
-        <German>7.62mm Subsonic 30Rnd Rk62 Magazine</German>
+        <German>7.62mm Unterschall 30 Schuss Rk62-Magazin</German>
         <Japanese>7.62mm 亜音速 30発入り Rk62 マガジン</Japanese>
         <Korean>7.62mm Subsonic 30Rnd Rk62 Magazine</Korean>
         <Chinesesimp>7.62mm Subsonic 30Rnd Rk62 Magazine</Chinesesimp>
@@ -2145,7 +2145,7 @@
         <Polish>7.62mm FMJ 30Rnd Black PMAG magazine</Polish>
         <Portuguese>7.62mm FMJ 30Rnd Black PMAG magazine</Portuguese>
         <Russian>7.62mm FMJ 30Rnd Black PMAG magazine</Russian>
-        <German>7.62mm FMJ 30Rnd Black PMAG magazine</German>
+        <German>7.62mm FMJ 30 Schuss Schwarzes PMAG</German>
         <Japanese>7.62mm FMJ 30発入り ブラック PMAG マガジン</Japanese>
         <Korean>7.62mm FMJ 30Rnd Black PMAG magazine</Korean>
         <Chinesesimp>7.62mm FMJ 30Rnd Black PMAG magazine</Chinesesimp>
@@ -2160,7 +2160,7 @@
         <Polish>7.62mm Tracer 30Rnd Black PMAG magazine</Polish>
         <Portuguese>7.62mm Tracer 30Rnd Black PMAG magazine</Portuguese>
         <Russian>7.62mm Tracer 30Rnd Black PMAG magazine</Russian>
-        <German>7.62mm Tracer 30Rnd Black PMAG magazine</German>
+        <German>7.62mm Leuchtspur 30 Schuss Schwarzes PMAG</German>
         <Japanese>7.62mm 曳光弾 30発入り ブラック PMAG マガジン</Japanese>
         <Korean>7.62mm Tracer 30Rnd Black PMAG magazine</Korean>
         <Chinesesimp>7.62mm Tracer 30Rnd Black PMAG magazine</Chinesesimp>
@@ -2175,7 +2175,7 @@
         <Polish>7.62mm FMJ 30Rnd Black PMAG magazine (Tracers Every 3)</Polish>
         <Portuguese>7.62mm FMJ 30Rnd Black PMAG magazine (Tracers Every 3)</Portuguese>
         <Russian>7.62mm FMJ 30Rnd Black PMAG magazine (Tracers Every 3)</Russian>
-        <German>7.62mm FMJ 30Rnd Black PMAG magazine (Tracers Every 3)</German>
+        <German>7.62mm FMJ 30 Schuss Black PMAG (Leuchtspur alle 3)</German>
         <Japanese>7.62mm FMJ 30発入り ブラック PMAG マガジン (3発毎に曳光弾)</Japanese>
         <Korean>7.62mm FMJ 30Rnd Black PMAG magazine (Tracers Every 3)</Korean>
         <Chinesesimp>7.62mm FMJ 30Rnd Black PMAG magazine (Tracers Every 3)</Chinesesimp>
@@ -2190,7 +2190,7 @@
         <Polish>7.62mm AP 30Rnd Black PMAG magazine</Polish>
         <Portuguese>7.62mm AP 30Rnd Black PMAG magazine</Portuguese>
         <Russian>7.62mm AP 30Rnd Black PMAG magazine</Russian>
-        <German>7.62mm AP 30Rnd Black PMAG magazine</German>
+        <German>7.62mm AP 30 Schuss Schwarzes PMAG</German>
         <Japanese>7.62mm AP 30発入り ブラック PMAG マガジン</Japanese>
         <Korean>7.62mm AP 30Rnd Black PMAG magazine</Korean>
         <Chinesesimp>7.62mm AP 30Rnd Black PMAG magazine</Chinesesimp>
@@ -2205,7 +2205,7 @@
         <Polish>7.62mm Subsonic 30Rnd Black PMAG magazine</Polish>
         <Portuguese>7.62mm Subsonic 30Rnd Black PMAG magazine</Portuguese>
         <Russian>7.62mm Subsonic 30Rnd Black PMAG magazine</Russian>
-        <German>7.62mm Subsonic 30Rnd Black PMAG magazine</German>
+        <German>7.62mm Unterschall 30 Schuss Schwarzes PMAG</German>
         <Japanese>7.62mm 亜音速 30発入り ブラック PMAG マガジン</Japanese>
         <Korean>7.62mm Subsonic 30Rnd Black PMAG magazine</Korean>
         <Chinesesimp>7.62mm Subsonic 30Rnd Black PMAG magazine</Chinesesimp>
@@ -2220,7 +2220,7 @@
         <Polish>7.62mm FMJ 30Rnd Desert PMAG magazine</Polish>
         <Portuguese>7.62mm FMJ 30Rnd Desert PMAG magazine</Portuguese>
         <Russian>7.62mm FMJ 30Rnd Desert PMAG magazine</Russian>
-        <German>7.62mm FMJ 30Rnd Desert PMAG magazine</German>
+        <German>7.62mm FMJ 30 Schuss Sandfarbenes PMAG</German>
         <Japanese>7.62mm FMJ 30発入り デザート PMAG マガジン</Japanese>
         <Korean>7.62mm FMJ 30Rnd Desert PMAG magazine</Korean>
         <Chinesesimp>7.62mm FMJ 30Rnd Desert PMAG magazine</Chinesesimp>
@@ -2235,7 +2235,7 @@
         <Polish>7.62mm Tracer 30Rnd Desert PMAG magazine</Polish>
         <Portuguese>7.62mm Tracer 30Rnd Desert PMAG magazine</Portuguese>
         <Russian>7.62mm Tracer 30Rnd Desert PMAG magazine</Russian>
-        <German>7.62mm Tracer 30Rnd Desert PMAG magazine</German>
+        <German>7.62mm Leuchtspur 30 Schuss Sandfarbenes PMAG</German>
         <Japanese>7.62mm 曳光弾 30発入り デザート PMAG マガジン</Japanese>
         <Korean>7.62mm Tracer 30Rnd Desert PMAG magazine</Korean>
         <Chinesesimp>7.62mm Tracer 30Rnd Desert PMAG magazine</Chinesesimp>
@@ -2250,7 +2250,7 @@
         <Polish>7.62mm FMJ 30Rnd Desert PMAG magazine (Tracers Every 3)</Polish>
         <Portuguese>7.62mm FMJ 30Rnd Desert PMAG magazine (Tracers Every 3)</Portuguese>
         <Russian>7.62mm FMJ 30Rnd Desert PMAG magazine (Tracers Every 3)</Russian>
-        <German>7.62mm FMJ 30Rnd Desert PMAG magazine (Tracers Every 3)</German>
+        <German>7.62mm FMJ 30 Schuss Sandfarbenes PMAG (Leuchtspur alle 3)</German>
         <Japanese>7.62mm FMJ 30発入り デザート PMAG マガジン (3発毎に曳光弾)</Japanese>
         <Korean>7.62mm FMJ 30Rnd Desert PMAG magazine (Tracers Every 3)</Korean>
         <Chinesesimp>7.62mm FMJ 30Rnd Desert PMAG magazine (Tracers Every 3)</Chinesesimp>
@@ -2265,7 +2265,7 @@
         <Polish>7.62mm AP 30Rnd Desert PMAG magazine</Polish>
         <Portuguese>7.62mm AP 30Rnd Desert PMAG magazine</Portuguese>
         <Russian>7.62mm AP 30Rnd Desert PMAG magazine</Russian>
-        <German>7.62mm AP 30Rnd Desert PMAG magazine</German>
+        <German>7.62mm AP 30 Schuss Sandfarbenes PMAG</German>
         <Japanese>7.62mm AP 30発入り デザート PMAG マガジン</Japanese>
         <Korean>7.62mm AP 30Rnd Desert PMAG magazine</Korean>
         <Chinesesimp>7.62mm AP 30Rnd Desert PMAG magazine</Chinesesimp>
@@ -2280,7 +2280,7 @@
         <Polish>7.62mm Subsonic 30Rnd Desert PMAG magazine</Polish>
         <Portuguese>7.62mm Subsonic 30Rnd Desert PMAG magazine</Portuguese>
         <Russian>7.62mm Subsonic 30Rnd Desert PMAG magazine</Russian>
-        <German>7.62mm Subsonic 30Rnd Desert PMAG magazine</German>
+        <German>7.62mm Unterschall 30 Schuss Sandfarbenes PMAG</German>
         <Japanese>7.62mm 亜音速 30発入り デザート PMAG マガジン</Japanese>
         <Korean>7.62mm Subsonic 30Rnd Desert PMAG magazine</Korean>
         <Chinesesimp>7.62mm Subsonic 30Rnd Desert PMAG magazine</Chinesesimp>
@@ -2295,7 +2295,7 @@
         <Polish>7.62mm FMJ 40Rnd RPK Magazine</Polish>
         <Portuguese>7.62mm FMJ 40Rnd RPK Magazine</Portuguese>
         <Russian>7.62mm FMJ 40Rnd RPK Magazine</Russian>
-        <German>7.62mm FMJ 40Rnd RPK Magazine</German>
+        <German>7.62mm FMJ 40 Schuss RPK-Magazin</German>
         <Japanese>7.62mm FMJ 40発入り RPK マガジン</Japanese>
         <Korean>7.62mm FMJ 40Rnd RPK Magazine</Korean>
         <Chinesesimp>7.62mm FMJ 40Rnd RPK Magazine</Chinesesimp>
@@ -2310,7 +2310,7 @@
         <Polish>7.62mm Tracer 40Rnd RPK Magazine</Polish>
         <Portuguese>7.62mm Tracer 40Rnd RPK Magazine</Portuguese>
         <Russian>7.62mm Tracer 40Rnd RPK Magazine</Russian>
-        <German>7.62mm Tracer 40Rnd RPK Magazine</German>
+        <German>7.62mm Leuchtspur 40 Schuss RPK-Magazin</German>
         <Japanese>7.62mm 曳光弾 40発入り RPK マガジン</Japanese>
         <Korean>7.62mm Tracer 40Rnd RPK Magazine</Korean>
         <Chinesesimp>7.62mm Tracer 40Rnd RPK Magazine</Chinesesimp>
@@ -2325,7 +2325,7 @@
         <Polish>7.62mm FMJ 40Rnd RPK Magazine (Tracers Every 3)</Polish>
         <Portuguese>7.62mm FMJ 40Rnd RPK Magazine (Tracers Every 3)</Portuguese>
         <Russian>7.62mm FMJ 40Rnd RPK Magazine (Tracers Every 3)</Russian>
-        <German>7.62mm FMJ 40Rnd RPK Magazine (Tracers Every 3)</German>
+        <German>7.62mm FMJ 40 Schuss RPK-Magazin (Leuchtspur alle 3)</German>
         <Japanese>7.62mm FMJ 40発入り RPK マガジン (3発毎に曳光弾)</Japanese>
         <Korean>7.62mm FMJ 40Rnd RPK Magazine (Tracers Every 3)</Korean>
         <Chinesesimp>7.62mm FMJ 40Rnd RPK Magazine (Tracers Every 3)</Chinesesimp>
@@ -2340,7 +2340,7 @@
         <Polish>7.62mm AP 40Rnd RPK Magazine</Polish>
         <Portuguese>7.62mm AP 40Rnd RPK Magazine</Portuguese>
         <Russian>7.62mm AP 40Rnd RPK Magazine</Russian>
-        <German>7.62mm AP 40Rnd RPK Magazine</German>
+        <German>7.62mm AP 40 Schuss RPK-Magazin</German>
         <Japanese>7.62mm AP 40発入り RPK マガジン</Japanese>
         <Korean>7.62mm AP 40Rnd RPK Magazine</Korean>
         <Chinesesimp>7.62mm AP 40Rnd RPK Magazine</Chinesesimp>
@@ -2355,7 +2355,7 @@
         <Polish>7.62mm FMJ 75Rnd RPK Magazine</Polish>
         <Portuguese>7.62mm FMJ 75Rnd RPK Magazine</Portuguese>
         <Russian>7.62mm FMJ 75Rnd RPK Magazine</Russian>
-        <German>7.62mm FMJ 75Rnd RPK Magazine</German>
+        <German>7.62mm FMJ 75 Schuss RPK-Magazin</German>
         <Japanese>7.62mm FMJ 75発入り RPK マガジン</Japanese>
         <Korean>7.62mm FMJ 75Rnd RPK Magazine</Korean>
         <Chinesesimp>7.62mm FMJ 75Rnd RPK Magazine</Chinesesimp>
@@ -2370,7 +2370,7 @@
         <Polish>7.62mm Tracer 75Rnd RPK Magazine</Polish>
         <Portuguese>7.62mm Tracer 75Rnd RPK Magazine</Portuguese>
         <Russian>7.62mm Tracer 75Rnd RPK Magazine</Russian>
-        <German>7.62mm Tracer 75Rnd RPK Magazine</German>
+        <German>7.62mm Leuchtspur 75 Schuss RPK-Magazin</German>
         <Japanese>7.62mm 曳光弾 75発入り RPK マガジン</Japanese>
         <Korean>7.62mm Tracer 75Rnd RPK Magazine</Korean>
         <Chinesesimp>7.62mm Tracer 75Rnd RPK Magazine</Chinesesimp>
@@ -2385,7 +2385,7 @@
         <Polish>7.62mm FMJ 75Rnd RPK Magazine (Tracers Every 3)</Polish>
         <Portuguese>7.62mm FMJ 75Rnd RPK Magazine (Tracers Every 3)</Portuguese>
         <Russian>7.62mm FMJ 75Rnd RPK Magazine (Tracers Every 3)</Russian>
-        <German>7.62mm FMJ 75Rnd RPK Magazine (Tracers Every 3)</German>
+        <German>7.62mm FMJ 75 Schuss RPK-Magazin (Leuchtspur alle 3)</German>
         <Japanese>7.62mm FMJ 75発入り RPK マガジン (3発毎に曳光弾)</Japanese>
         <Korean>7.62mm FMJ 75Rnd RPK Magazine (Tracers Every 3)</Korean>
         <Chinesesimp>7.62mm FMJ 75Rnd RPK Magazine (Tracers Every 3)</Chinesesimp>
@@ -2400,7 +2400,7 @@
         <Polish>7.62mm AP 75Rnd RPK Magazine</Polish>
         <Portuguese>7.62mm AP 75Rnd RPK Magazine</Portuguese>
         <Russian>7.62mm AP 75Rnd RPK Magazine</Russian>
-        <German>7.62mm AP 75Rnd RPK Magazine</German>
+        <German>7.62mm AP 75 Schuss RPK-Magazin</German>
         <Japanese>7.62mm AP 75発入り RPK マガジン</Japanese>
         <Korean>7.62mm AP 75Rnd RPK Magazine</Korean>
         <Chinesesimp>7.62mm AP 75Rnd RPK Magazine</Chinesesimp>

--- a/hlc_core/Stringtable.xml
+++ b/hlc_core/Stringtable.xml
@@ -688,7 +688,7 @@
         <Polish>White Smoke</Polish>
         <Portuguese>White Smoke</Portuguese>
         <Russian>White Smoke</Russian>
-        <German>White Smoke</German>
+        <German>Weißer Nebel</German>
         <Japanese>発煙弾 (白)</Japanese>
         <Korean>White Smoke</Korean>
         <Chinesesimp>White Smoke</Chinesesimp>
@@ -703,7 +703,7 @@
         <Polish>Red Smoke</Polish>
         <Portuguese>Red Smoke</Portuguese>
         <Russian>Red Smoke</Russian>
-        <German>Red Smoke</German>
+        <German>Roter Nebel</German>
         <Japanese>発煙弾 (赤)</Japanese>
         <Korean>Red Smoke</Korean>
         <Chinesesimp>Red Smoke</Chinesesimp>
@@ -718,7 +718,7 @@
         <Polish>Green Smoke</Polish>
         <Portuguese>Green Smoke</Portuguese>
         <Russian>Green Smoke</Russian>
-        <German>Green Smoke</German>
+        <German>Grüner Nebel</German>
         <Japanese>発煙弾 (緑)</Japanese>
         <Korean>Green Smoke</Korean>
         <Chinesesimp>Green Smoke</Chinesesimp>
@@ -733,7 +733,7 @@
         <Polish>Yellow Smoke</Polish>
         <Portuguese>Yellow Smoke</Portuguese>
         <Russian>Yellow Smoke</Russian>
-        <German>Yellow Smoke</German>
+        <German>Gelber Nebel</German>
         <Japanese>発煙弾 (黄)</Japanese>
         <Korean>Yellow Smoke</Korean>
         <Chinesesimp>Yellow Smoke</Chinesesimp>
@@ -748,7 +748,7 @@
         <Polish>Orange Smoke</Polish>
         <Portuguese>Orange Smoke</Portuguese>
         <Russian>Orange Smoke</Russian>
-        <German>Orange Smoke</German>
+        <German>Orangener Nebel</German>
         <Japanese>発煙弾 (橙)</Japanese>
         <Korean>Orange Smoke</Korean>
         <Chinesesimp>Orange Smoke</Chinesesimp>
@@ -763,7 +763,7 @@
         <Polish>Purple Smoke</Polish>
         <Portuguese>Purple Smoke</Portuguese>
         <Russian>Purple Smoke</Russian>
-        <German>Purple Smoke</German>
+        <German>Lila Nebel</German>
         <Japanese>発煙弾 (紫)</Japanese>
         <Korean>Purple Smoke</Korean>
         <Chinesesimp>Purple Smoke</Chinesesimp>
@@ -778,7 +778,7 @@
         <Polish>Blue Smoke</Polish>
         <Portuguese>Blue Smoke</Portuguese>
         <Russian>Blue Smoke</Russian>
-        <German>Blue Smoke</German>
+        <German>Blauer Nebel</German>
         <Japanese>発煙弾 (青)</Japanese>
         <Korean>Blue Smoke</Korean>
         <Chinesesimp>Blue Smoke</Chinesesimp>
@@ -2415,115 +2415,115 @@
         <Polish>VOG25P HE Round</Polish>
         <Portuguese>VOG25P HE Round</Portuguese>
         <Russian>VOG25P HE Round</Russian>
-        <German>VOG25P HE Round</German>
+        <German>VOG25P Sprenggranate</German>
         <Japanese>VOG25P HE 弾</Japanese>
         <Korean>VOG25P HE Round</Korean>
         <Chinesesimp>VOG25P HE Round</Chinesesimp>
       </Key>
       <Key ID="STR_NIA_GRD40white_AK">
-        <Original>GRD-40 White Smoke (White)</Original>
-        <English>GRD-40 White Smoke (White)</English>
-        <Czech>GRD-40 White Smoke (White)</Czech>
-        <French>GRD-40 White Smoke (White)</French>
-        <Spanish>GRD-40 White Smoke (White)</Spanish>
-        <Italian>GRD-40 White Smoke (White)</Italian>
-        <Polish>GRD-40 White Smoke (White)</Polish>
-        <Portuguese>GRD-40 White Smoke (White)</Portuguese>
-        <Russian>GRD-40 White Smoke (White)</Russian>
-        <German>GRD-40 White Smoke (White)</German>
+        <Original>GRD-40 Smoke (White)</Original>
+        <English>GRD-40 Smoke (White)</English>
+        <Czech>GRD-40 Smoke (White)</Czech>
+        <French>GRD-40 Smoke (White)</French>
+        <Spanish>GRD-40 Smoke (White)</Spanish>
+        <Italian>GRD-40 Smoke (White)</Italian>
+        <Polish>GRD-40 Smoke (White)</Polish>
+        <Portuguese>GRD-40 Smoke (White)</Portuguese>
+        <Russian>GRD-40 Smoke (White)</Russian>
+        <German>GRD-40 Nebelgranate (Weiß)</German>
         <Japanese>GRD-40 発煙弾 (白)</Japanese>
-        <Korean>GRD-40 White Smoke (White)</Korean>
-        <Chinesesimp>GRD-40 White Smoke (White)</Chinesesimp>
+        <Korean>GRD-40 Smoke (White)</Korean>
+        <Chinesesimp>GRD-40 Smoke (White)</Chinesesimp>
       </Key>
       <Key ID="STR_NIA_GRD40Red_AK">
-        <Original>GRD-40 White Smoke (Red)</Original>
-        <English>GRD-40 White Smoke (Red)</English>
-        <Czech>GRD-40 White Smoke (Red)</Czech>
-        <French>GRD-40 White Smoke (Red)</French>
-        <Spanish>GRD-40 White Smoke (Red)</Spanish>
-        <Italian>GRD-40 White Smoke (Red)</Italian>
-        <Polish>GRD-40 White Smoke (Red)</Polish>
-        <Portuguese>GRD-40 White Smoke (Red)</Portuguese>
-        <Russian>GRD-40 White Smoke (Red)</Russian>
-        <German>GRD-40 White Smoke (Red)</German>
+        <Original>GRD-40 Smoke (Red)</Original>
+        <English>GRD-40 Smoke (Red)</English>
+        <Czech>GRD-40 Smoke (Red)</Czech>
+        <French>GRD-40 Smoke (Red)</French>
+        <Spanish>GRD-40 Smoke (Red)</Spanish>
+        <Italian>GRD-40 Smoke (Red)</Italian>
+        <Polish>GRD-40 Smoke (Red)</Polish>
+        <Portuguese>GRD-40 Smoke (Red)</Portuguese>
+        <Russian>GRD-40 Smoke (Red)</Russian>
+        <German>GRD-40 Nebelgranate (Rot)</German>
         <Japanese>GRD-40 発煙弾 (赤)</Japanese>
-        <Korean>GRD-40 White Smoke (Red)</Korean>
-        <Chinesesimp>GRD-40 White Smoke (Red)</Chinesesimp>
+        <Korean>GRD-40 Smoke (Red)</Korean>
+        <Chinesesimp>GRD-40 Smoke (Red)</Chinesesimp>
       </Key>
       <Key ID="STR_NIA_GRD40Green_AK">
-        <Original>GRD-40 White Smoke (Green)</Original>
-        <English>GRD-40 White Smoke (Green)</English>
-        <Czech>GRD-40 White Smoke (Green)</Czech>
-        <French>GRD-40 White Smoke (Green)</French>
-        <Spanish>GRD-40 White Smoke (Green)</Spanish>
-        <Italian>GRD-40 White Smoke (Green)</Italian>
-        <Polish>GRD-40 White Smoke (Green)</Polish>
-        <Portuguese>GRD-40 White Smoke (Green)</Portuguese>
-        <Russian>GRD-40 White Smoke (Green)</Russian>
-        <German>GRD-40 White Smoke (Green)</German>
+        <Original>GRD-40 Smoke (Green)</Original>
+        <English>GRD-40 Smoke (Green)</English>
+        <Czech>GRD-40 Smoke (Green)</Czech>
+        <French>GRD-40 Smoke (Green)</French>
+        <Spanish>GRD-40 Smoke (Green)</Spanish>
+        <Italian>GRD-40 Smoke (Green)</Italian>
+        <Polish>GRD-40 Smoke (Green)</Polish>
+        <Portuguese>GRD-40 Smoke (Green)</Portuguese>
+        <Russian>GRD-40 Smoke (Green)</Russian>
+        <German>GRD-40 Nebelgranate (Grün)</German>
         <Japanese>GRD-40 発煙弾 (緑)</Japanese>
-        <Korean>GRD-40 White Smoke (Green)</Korean>
-        <Chinesesimp>GRD-40 White Smoke (Green)</Chinesesimp>
+        <Korean>GRD-40 Smoke (Green)</Korean>
+        <Chinesesimp>GRD-40 Smoke (Green)</Chinesesimp>
       </Key>
       <Key ID="STR_NIA_GRD40Yellow_AK">
-        <Original>GRD-40 White Smoke (Yellow)</Original>
-        <English>GRD-40 White Smoke (Yellow)</English>
-        <Czech>GRD-40 White Smoke (Yellow)</Czech>
-        <French>GRD-40 White Smoke (Yellow)</French>
-        <Spanish>GRD-40 White Smoke (Yellow)</Spanish>
-        <Italian>GRD-40 White Smoke (Yellow)</Italian>
-        <Polish>GRD-40 White Smoke (Yellow)</Polish>
-        <Portuguese>GRD-40 White Smoke (Yellow)</Portuguese>
-        <Russian>GRD-40 White Smoke (Yellow)</Russian>
-        <German>GRD-40 White Smoke (Yellow)</German>
+        <Original>GRD-40 Smoke (Yellow)</Original>
+        <English>GRD-40 Smoke (Yellow)</English>
+        <Czech>GRD-40 Smoke (Yellow)</Czech>
+        <French>GRD-40 Smoke (Yellow)</French>
+        <Spanish>GRD-40 Smoke (Yellow)</Spanish>
+        <Italian>GRD-40 Smoke (Yellow)</Italian>
+        <Polish>GRD-40 Smoke (Yellow)</Polish>
+        <Portuguese>GRD-40 Smoke (Yellow)</Portuguese>
+        <Russian>GRD-40 Smoke (Yellow)</Russian>
+        <German>GRD-40 Smoke (Gelb)</German>
         <Japanese>GRD-40 発煙弾 (黄)</Japanese>
-        <Korean>GRD-40 White Smoke (Yellow)</Korean>
-        <Chinesesimp>GRD-40 White Smoke (Yellow)</Chinesesimp>
+        <Korean>GRD-40 Smoke (Yellow)</Korean>
+        <Chinesesimp>GRD-40 Smoke (Yellow)</Chinesesimp>
       </Key>
       <Key ID="STR_NIA_GRD40Orange_AK">
-        <Original>GRD-40 White Smoke (Orange)</Original>
-        <English>GRD-40 White Smoke (Orange)</English>
-        <Czech>GRD-40 White Smoke (Orange)</Czech>
-        <French>GRD-40 White Smoke (Orange)</French>
-        <Spanish>GRD-40 White Smoke (Orange)</Spanish>
-        <Italian>GRD-40 White Smoke (Orange)</Italian>
-        <Polish>GRD-40 White Smoke (Orange)</Polish>
-        <Portuguese>GRD-40 White Smoke (Orange)</Portuguese>
-        <Russian>GRD-40 White Smoke (Orange)</Russian>
-        <German>GRD-40 White Smoke (Orange)</German>
+        <Original>GRD-40 Smoke (Orange)</Original>
+        <English>GRD-40 Smoke (Orange)</English>
+        <Czech>GRD-40 Smoke (Orange)</Czech>
+        <French>GRD-40 Smoke (Orange)</French>
+        <Spanish>GRD-40 Smoke (Orange)</Spanish>
+        <Italian>GRD-40 Smoke (Orange)</Italian>
+        <Polish>GRD-40 Smoke (Orange)</Polish>
+        <Portuguese>GRD-40 Smoke (Orange)</Portuguese>
+        <Russian>GRD-40 Smoke (Orange)</Russian>
+        <German>GRD-40 Nebelgranate (Orange)</German>
         <Japanese>GRD-40 発煙弾 (橙)</Japanese>
-        <Korean>GRD-40 White Smoke (Orange)</Korean>
-        <Chinesesimp>GRD-40 White Smoke (Orange)</Chinesesimp>
+        <Korean>GRD-40 Smoke (Orange)</Korean>
+        <Chinesesimp>GRD-40 Smoke (Orange)</Chinesesimp>
       </Key>
       <Key ID="STR_NIA_GRD40Purple_AK">
-        <Original>GRD-40 White Smoke (Purple)</Original>
-        <English>GRD-40 White Smoke (Purple)</English>
-        <Czech>GRD-40 White Smoke (Purple)</Czech>
-        <French>GRD-40 White Smoke (Purple)</French>
-        <Spanish>GRD-40 White Smoke (Purple)</Spanish>
-        <Italian>GRD-40 White Smoke (Purple)</Italian>
-        <Polish>GRD-40 White Smoke (Purple)</Polish>
-        <Portuguese>GRD-40 White Smoke (Purple)</Portuguese>
-        <Russian>GRD-40 White Smoke (Purple)</Russian>
-        <German>GRD-40 White Smoke (Purple)</German>
+        <Original>GRD-40 Smoke (Purple)</Original>
+        <English>GRD-40 Smoke (Purple)</English>
+        <Czech>GRD-40 Smoke (Purple)</Czech>
+        <French>GRD-40 Smoke (Purple)</French>
+        <Spanish>GRD-40 Smoke (Purple)</Spanish>
+        <Italian>GRD-40 Smoke (Purple)</Italian>
+        <Polish>GRD-40 Smoke (Purple)</Polish>
+        <Portuguese>GRD-40 Smoke (Purple)</Portuguese>
+        <Russian>GRD-40 Smoke (Purple)</Russian>
+        <German>GRD-40 Nebelgranate (Lila)</German>
         <Japanese>GRD-40 発煙弾 (紫)</Japanese>
-        <Korean>GRD-40 White Smoke (Purple)</Korean>
-        <Chinesesimp>GRD-40 White Smoke (Purple)</Chinesesimp>
+        <Korean>GRD-40 Smoke (Purple)</Korean>
+        <Chinesesimp>GRD-40 Smoke (Purple)</Chinesesimp>
       </Key>
       <Key ID="STR_NIA_GRD40Blue_AK">
-        <Original>GRD-40 White Smoke (Blue)</Original>
-        <English>GRD-40 White Smoke (Blue)</English>
-        <Czech>GRD-40 White Smoke (Blue)</Czech>
-        <French>GRD-40 White Smoke (Blue)</French>
-        <Spanish>GRD-40 White Smoke (Blue)</Spanish>
-        <Italian>GRD-40 White Smoke (Blue)</Italian>
-        <Polish>GRD-40 White Smoke (Blue)</Polish>
-        <Portuguese>GRD-40 White Smoke (Blue)</Portuguese>
-        <Russian>GRD-40 White Smoke (Blue)</Russian>
-        <German>GRD-40 White Smoke (Blue)</German>
+        <Original>GRD-40 Smoke (Blue)</Original>
+        <English>GRD-40 Smoke (Blue)</English>
+        <Czech>GRD-40 Smoke (Blue)</Czech>
+        <French>GRD-40 Smoke (Blue)</French>
+        <Spanish>GRD-40 Smoke (Blue)</Spanish>
+        <Italian>GRD-40 Smoke (Blue)</Italian>
+        <Polish>GRD-40 Smoke (Blue)</Polish>
+        <Portuguese>GRD-40 Smoke (Blue)</Portuguese>
+        <Russian>GRD-40 Smoke (Blue)</Russian>
+        <German>GRD-40 Nebelgranate (Blau)</German>
         <Japanese>GRD-40 発煙弾 (青)</Japanese>
-        <Korean>GRD-40 White Smoke (Blue)</Korean>
-        <Chinesesimp>GRD-40 White Smoke (Blue)</Chinesesimp>
+        <Korean>GRD-40 Smoke (Blue)</Korean>
+        <Chinesesimp>GRD-40 Smoke (Blue)</Chinesesimp>
       </Key>
       <Key ID="STR_NIA_100Rnd_762x51_B_M60E4">
         <Original>7.62mm EPR 100Rnd M13-linked belt</Original>

--- a/hlc_core/Stringtable.xml
+++ b/hlc_core/Stringtable.xml
@@ -57,7 +57,7 @@
         <Polish>FMJ Subsonic</Polish>
         <Portuguese>FMJ Subsonic</Portuguese>
         <Russian>FMJ Subsonic</Russian>
-        <German>FMJ Subsonic</German>
+        <German>FMJ Unterschall</German>
         <Japanese>FMJ 亜音速</Japanese>
         <Korean>FMJ Subsonic</Korean>
         <Chinesesimp>FMJ Subsonic</Chinesesimp>
@@ -72,7 +72,7 @@
         <Polish>M856A1 Tracer</Polish>
         <Portuguese>M856A1 Tracer</Portuguese>
         <Russian>M856A1 Tracer</Russian>
-        <German>M856A1 Tracer</German>
+        <German>M856A1 L'Spur</German>
         <Japanese>M856A1 曳光弾</Japanese>
         <Korean>M856A1 Tracer</Korean>
         <Chinesesimp>M856A1 Tracer</Chinesesimp>
@@ -117,7 +117,7 @@
         <Polish>EPR/Tracer</Polish>
         <Portuguese>EPR/Tracer</Portuguese>
         <Russian>EPR/Tracer</Russian>
-        <German>EPR/Tracer</German>
+        <German>EPR/L'Spur</German>
         <Japanese>EPR/曳光弾</Japanese>
         <Korean>EPR/Tracer</Korean>
         <Chinesesimp>EPR/Tracer</Chinesesimp>
@@ -162,7 +162,7 @@
         <Polish>FMJ Subsonic</Polish>
         <Portuguese>FMJ Subsonic</Portuguese>
         <Russian>FMJ Subsonic</Russian>
-        <German>FMJ Subsonic</German>
+        <German>FMJ Unterschall</German>
         <Japanese>FMJ 亜音速</Japanese>
         <Korean>FMJ Subsonic</Korean>
         <Chinesesimp>FMJ Subsonic</Chinesesimp>
@@ -177,7 +177,7 @@
         <Polish>Tracer</Polish>
         <Portuguese>Tracer</Portuguese>
         <Russian>Tracer</Russian>
-        <German>Tracer</German>
+        <German>L'Spur</German>
         <Japanese>曳光弾</Japanese>
         <Korean>Tracer</Korean>
         <Chinesesimp>Tracer</Chinesesimp>
@@ -222,7 +222,7 @@
         <Polish>FMJ/Tracer</Polish>
         <Portuguese>FMJ/Tracer</Portuguese>
         <Russian>FMJ/Tracer</Russian>
-        <German>FMJ/Tracer</German>
+        <German>FMJ/L'Spur</German>
         <Japanese>FMJ/曳光弾</Japanese>
         <Korean>FMJ/Tracer</Korean>
         <Chinesesimp>FMJ/Tracer</Chinesesimp>
@@ -282,7 +282,7 @@
         <Polish>M62A1 Tracer</Polish>
         <Portuguese>M62A1 Tracer</Portuguese>
         <Russian>M62A1 Tracer</Russian>
-        <German>M62A1 Tracer</German>
+        <German>M62A1 L'Spur</German>
         <Japanese>M62A1 曳光弾</Japanese>
         <Korean>M62A1 Tracer</Korean>
         <Chinesesimp>M62A1 Tracer</Chinesesimp>
@@ -312,7 +312,7 @@
         <Polish>FMJ Subsonic</Polish>
         <Portuguese>FMJ Subsonic</Portuguese>
         <Russian>FMJ Subsonic</Russian>
-        <German>FMJ Subsonic</German>
+        <German>FMJ Unterschall</German>
         <Japanese>FMJ 亜音速</Japanese>
         <Korean>FMJ Subsonic</Korean>
         <Chinesesimp>FMJ Subsonic</Chinesesimp>
@@ -327,7 +327,7 @@
         <Polish>Mk319/Tracer</Polish>
         <Portuguese>Mk319/Tracer</Portuguese>
         <Russian>Mk319/Tracer</Russian>
-        <German>Mk319/Tracer</German>
+        <German>Mk319/L'Spur</German>
         <Japanese>Mk319/曳光弾</Japanese>
         <Korean>Mk319/Tracer</Korean>
         <Chinesesimp>Mk319/Tracer</Chinesesimp>
@@ -357,7 +357,7 @@
         <Polish>EPR/Tracer</Polish>
         <Portuguese>EPR/Tracer</Portuguese>
         <Russian>EPR/Tracer</Russian>
-        <German>EPR/Tracer</German>
+        <German>EPR/L'Spur</German>
         <Japanese>EPR/曳光弾</Japanese>
         <Korean>EPR/Tracer</Korean>
         <Chinesesimp>EPR/Tracer</Chinesesimp>
@@ -387,7 +387,7 @@
         <Polish>7U1 Subsonic</Polish>
         <Portuguese>7U1 Subsonic</Portuguese>
         <Russian>7U1 Subsonic</Russian>
-        <German>7U1 Subsonic</German>
+        <German>7U1 Unterschall</German>
         <Japanese>7U1 亜音速</Japanese>
         <Korean>7U1 Subsonic</Korean>
         <Chinesesimp>7U1 Subsonic</Chinesesimp>
@@ -402,7 +402,7 @@
         <Polish>7T3 Tracer</Polish>
         <Portuguese>7T3 Tracer</Portuguese>
         <Russian>7T3 Tracer</Russian>
-        <German>7T3 Tracer</German>
+        <German>7T3 L'Spur</German>
         <Japanese>7T3 曳光弾</Japanese>
         <Korean>7T3 Tracer</Korean>
         <Chinesesimp>7T3 Tracer</Chinesesimp>
@@ -417,7 +417,7 @@
         <Polish>FMJ/Tracer</Polish>
         <Portuguese>FMJ/Tracer</Portuguese>
         <Russian>FMJ/Tracer</Russian>
-        <German>FMJ/Tracer</German>
+        <German>FMJ/L'Spur</German>
         <Japanese>FMJ/曳光弾</Japanese>
         <Korean>FMJ/Tracer</Korean>
         <Chinesesimp>FMJ/Tracer</Chinesesimp>
@@ -462,7 +462,7 @@
         <Polish>57-N-231P Tracer</Polish>
         <Portuguese>57-N-231P Tracer</Portuguese>
         <Russian>57-N-231P Tracer</Russian>
-        <German>57-N-231P Tracer</German>
+        <German>57-N-231P L'Spur</German>
         <Japanese>57-N-231P 曳光弾</Japanese>
         <Korean>57-N-231P Tracer</Korean>
         <Chinesesimp>57-N-231P Tracer</Chinesesimp>
@@ -477,7 +477,7 @@
         <Polish>FMJ/Tracer</Polish>
         <Portuguese>FMJ/Tracer</Portuguese>
         <Russian>FMJ/Tracer</Russian>
-        <German>FMJ/Tracer</German>
+        <German>FMJ/L'Spur</German>
         <Japanese>FMJ/曳光弾</Japanese>
         <Korean>FMJ/Tracer</Korean>
         <Chinesesimp>FMJ/Tracer</Chinesesimp>
@@ -507,7 +507,7 @@
         <Polish>57-N-321U Subsonic</Polish>
         <Portuguese>57-N-321U Subsonic</Portuguese>
         <Russian>57-N-321U Subsonic</Russian>
-        <German>57-N-321U Subsonic</German>
+        <German>57-N-321U Unterschall</German>
         <Japanese>57-N-321U 亜音速</Japanese>
         <Korean>57-N-321U Subsonic</Korean>
         <Chinesesimp>57-N-321U Subsonic</Chinesesimp>
@@ -552,7 +552,7 @@
         <Polish>FMJ Subsonic</Polish>
         <Portuguese>FMJ Subsonic</Portuguese>
         <Russian>FMJ Subsonic</Russian>
-        <German>FMJ Subsonic</German>
+        <German>FMJ Unterschall</German>
         <Japanese>FMJ 亜音速</Japanese>
         <Korean>FMJ Subsonic</Korean>
         <Chinesesimp>FMJ Subsonic</Chinesesimp>
@@ -628,7 +628,7 @@
         <Polish>JHP Subsonic</Polish>
         <Portuguese>JHP Subsonic</Portuguese>
         <Russian>JHP Subsonic</Russian>
-        <German>JHP Subsonic</German>
+        <German>JHP Unterschall</German>
         <Japanese>JHP Subsonic</Japanese>
         <Korean>JHP Subsonic</Korean>
         <Chinesesimp>JHP Subsonic</Chinesesimp>
@@ -673,7 +673,7 @@
         <Polish>HE Grenade</Polish>
         <Portuguese>HE Grenade</Portuguese>
         <Russian>HE Grenade</Russian>
-        <German>HE Grenade</German>
+        <German>Sprenggranate</German>
         <Japanese>HE グレネード</Japanese>
         <Korean>HE Grenade</Korean>
         <Chinesesimp>HE Grenade</Chinesesimp>
@@ -795,7 +795,7 @@
         <Polish>5.56mm EPR 30Rnd STANAG</Polish>
         <Portuguese>5.56mm EPR 30Rnd STANAG</Portuguese>
         <Russian>5.56mm EPR 30Rnd STANAG</Russian>
-        <German>5.56mm EPR 30Rnd STANAG</German>
+        <German>5.56mm EPR 30 Schuss STANAG</German>
         <Japanese>5.56mm EPR 30発入り STANAG</Japanese>
         <Korean>5.56mm EPR 30Rnd STANAG</Korean>
         <Chinesesimp>5.56mm EPR 30Rnd STANAG</Chinesesimp>
@@ -810,7 +810,7 @@
         <Polish>5.56mm SOST 30Rnd STANAG</Polish>
         <Portuguese>5.56mm SOST 30Rnd STANAG</Portuguese>
         <Russian>5.56mm SOST 30Rnd STANAG</Russian>
-        <German>5.56mm SOST 30Rnd STANAG</German>
+        <German>5.56mm SOST 30 Schuss STANAG</German>
         <Japanese>5.56mm SOST 30発入り STANAG</Japanese>
         <Korean>5.56mm SOST 30Rnd STANAG</Korean>
         <Chinesesimp>5.56mm SOST 30Rnd STANAG</Chinesesimp>
@@ -825,7 +825,7 @@
         <Polish>5.56mm SBLR 30Rnd STANAG</Polish>
         <Portuguese>5.56mm SBLR 30Rnd STANAG</Portuguese>
         <Russian>5.56mm SBLR 30Rnd STANAG</Russian>
-        <German>5.56mm SBLR 30Rnd STANAG</German>
+        <German>5.56mm SBLR 30 Schuss STANAG</German>
         <Japanese>5.56mm SBLR 30発入り STANAG</Japanese>
         <Korean>5.56mm SBLR 30Rnd STANAG</Korean>
         <Chinesesimp>5.56mm SBLR 30Rnd STANAG</Chinesesimp>
@@ -840,7 +840,7 @@
         <Polish>5.56mm Subsonic 30Rnd STANAG</Polish>
         <Portuguese>5.56mm Subsonic 30Rnd STANAG</Portuguese>
         <Russian>5.56mm Subsonic 30Rnd STANAG</Russian>
-        <German>5.56mm Subsonic 30Rnd STANAG</German>
+        <German>5.56mm Unterschall 30 Schuss STANAG</German>
         <Japanese>5.56mm 亜音速 30発入り STANAG</Japanese>
         <Korean>5.56mm Subsonic 30Rnd STANAG</Korean>
         <Chinesesimp>5.56mm Subsonic 30Rnd STANAG</Chinesesimp>
@@ -855,7 +855,7 @@
         <Polish>5.56mm EPR 30Rnd STANAG (Tracers every 4)</Polish>
         <Portuguese>5.56mm EPR 30Rnd STANAG (Tracers every 4)</Portuguese>
         <Russian>5.56mm EPR 30Rnd STANAG (Tracers every 4)</Russian>
-        <German>5.56mm EPR 30Rnd STANAG (Tracers every 4)</German>
+        <German>5.56mm EPR 30 Schuss STANAG (Leuchtspur alle 4)</German>
         <Japanese>5.56mm EPR 30発入り STANAG (4発毎に曳光弾)</Japanese>
         <Korean>5.56mm EPR 30Rnd STANAG (Tracers every 4)</Korean>
         <Chinesesimp>5.56mm EPR 30Rnd STANAG (Tracers every 4)</Chinesesimp>
@@ -870,7 +870,7 @@
         <Polish>5.56mm Tracer 30Rnd STANAG</Polish>
         <Portuguese>5.56mm Tracer 30Rnd STANAG</Portuguese>
         <Russian>5.56mm Tracer 30Rnd STANAG</Russian>
-        <German>5.56mm Tracer 30Rnd STANAG</German>
+        <German>5.56mm Leuchtspur 30 Schuss STANAG</German>
         <Japanese>5.56mm 曳光弾 30発入り STANAG</Japanese>
         <Korean>5.56mm Tracer 30Rnd STANAG</Korean>
         <Chinesesimp>5.56mm Tracer 30Rnd STANAG</Chinesesimp>
@@ -885,7 +885,7 @@
         <Polish>5.56mm IR-DIM 30Rnd STANAG</Polish>
         <Portuguese>5.56mm IR-DIM 30Rnd STANAG</Portuguese>
         <Russian>5.56mm IR-DIM 30Rnd STANAG</Russian>
-        <German>5.56mm IR-DIM 30Rnd STANAG</German>
+        <German>5.56mm IR-DIM 30 Schuss STANAG</German>
         <Japanese>5.56mm IR-DIM 30発入り STANAG</Japanese>
         <Korean>5.56mm IR-DIM 30Rnd STANAG</Korean>
         <Chinesesimp>5.56mm IR-DIM 30Rnd STANAG</Chinesesimp>
@@ -900,7 +900,7 @@
         <Polish>5.56mm EPR 30Rnd STANAG (IR-DIM every 4)</Polish>
         <Portuguese>5.56mm EPR 30Rnd STANAG (IR-DIM every 4)</Portuguese>
         <Russian>5.56mm EPR 30Rnd STANAG (IR-DIM every 4)</Russian>
-        <German>5.56mm EPR 30Rnd STANAG (IR-DIM every 4)</German>
+        <German>5.56mm EPR 30 Schuss STANAG (IR-DIM alle 4)</German>
         <Japanese>5.56mm EPR 30発入り STANAG (4発毎にIR-DIM)</Japanese>
         <Korean>5.56mm EPR 30Rnd STANAG (IR-DIM every 4)</Korean>
         <Chinesesimp>5.56mm EPR 30Rnd STANAG (IR-DIM every 4)</Chinesesimp>
@@ -915,7 +915,7 @@
         <Polish>5.56mm EPR 50Rnd X15</Polish>
         <Portuguese>5.56mm EPR 50Rnd X15</Portuguese>
         <Russian>5.56mm EPR 50Rnd X15</Russian>
-        <German>5.56mm EPR 50Rnd X15</German>
+        <German>5.56mm EPR 50 Schuss X15</German>
         <Japanese>5.56mm EPR 50発入り X15</Japanese>
         <Korean>5.56mm EPR 50Rnd X15</Korean>
         <Chinesesimp>5.56mm EPR 50Rnd X15</Chinesesimp>
@@ -930,7 +930,7 @@
         <Polish>5.56mm SOST 50Rnd X15</Polish>
         <Portuguese>5.56mm SOST 50Rnd X15</Portuguese>
         <Russian>5.56mm SOST 50Rnd X15</Russian>
-        <German>5.56mm SOST 50Rnd X15</German>
+        <German>5.56mm SOST 50 Schuss X15</German>
         <Japanese>5.56mm SOST 50発入り X15</Japanese>
         <Korean>5.56mm SOST 50Rnd X15</Korean>
         <Chinesesimp>5.56mm SOST 50Rnd X15</Chinesesimp>
@@ -945,7 +945,7 @@
         <Polish>5.56mm SBLR 50Rnd X15</Polish>
         <Portuguese>5.56mm SBLR 50Rnd X15</Portuguese>
         <Russian>5.56mm SBLR 50Rnd X15</Russian>
-        <German>5.56mm SBLR 50Rnd X15</German>
+        <German>5.56mm SBLR 50 Schuss X15</German>
         <Japanese>5.56mm SBLR 50発入り X15</Japanese>
         <Korean>5.56mm SBLR 50Rnd X15</Korean>
         <Chinesesimp>5.56mm SBLR 50Rnd X15</Chinesesimp>
@@ -960,7 +960,7 @@
         <Polish>5.56mm Subsonic 50Rnd X15</Polish>
         <Portuguese>5.56mm Subsonic 50Rnd X15</Portuguese>
         <Russian>5.56mm Subsonic 50Rnd X15</Russian>
-        <German>5.56mm Subsonic 50Rnd X15</German>
+        <German>5.56mm Unterschall 50 Schuss X15</German>
         <Japanese>5.56mm 亜音速 50発入り X15</Japanese>
         <Korean>5.56mm Subsonic 50Rnd X15</Korean>
         <Chinesesimp>5.56mm Subsonic 50Rnd X15</Chinesesimp>
@@ -975,7 +975,7 @@
         <Polish>5.56mm EPR 50Rnd X15 (Tracers every 4)</Polish>
         <Portuguese>5.56mm EPR 50Rnd X15 (Tracers every 4)</Portuguese>
         <Russian>5.56mm EPR 50Rnd X15 (Tracers every 4)</Russian>
-        <German>5.56mm EPR 50Rnd X15 (Tracers every 4)</German>
+        <German>5.56mm EPR 50 Schuss X15 (Leuchtspur alle 4)</German>
         <Japanese>5.56mm EPR 50発入り X15 (4発毎に曳光弾)</Japanese>
         <Korean>5.56mm EPR 50Rnd X15 (Tracers every 4)</Korean>
         <Chinesesimp>5.56mm EPR 50Rnd X15 (Tracers every 4)</Chinesesimp>
@@ -990,7 +990,7 @@
         <Polish>5.56mm Tracer 50Rnd X15</Polish>
         <Portuguese>5.56mm Tracer 50Rnd X15</Portuguese>
         <Russian>5.56mm Tracer 50Rnd X15</Russian>
-        <German>5.56mm Tracer 50Rnd X15</German>
+        <German>5.56mm Leuchtspur 50 Schuss X15</German>
         <Japanese>5.56mm 曳光弾 50発入り X15</Japanese>
         <Korean>5.56mm Tracer 50Rnd X15</Korean>
         <Chinesesimp>5.56mm Tracer 50Rnd X15</Chinesesimp>
@@ -1005,7 +1005,7 @@
         <Polish>5.56mm IR-DIM 50Rnd X15</Polish>
         <Portuguese>5.56mm IR-DIM 50Rnd X15</Portuguese>
         <Russian>5.56mm IR-DIM 50Rnd X15</Russian>
-        <German>5.56mm IR-DIM 50Rnd X15</German>
+        <German>5.56mm IR-DIM 50 Schuss X15</German>
         <Japanese>5.56mm IR-DIM 50発入り X15</Japanese>
         <Korean>5.56mm IR-DIM 50Rnd X15</Korean>
         <Chinesesimp>5.56mm IR-DIM 50Rnd X15</Chinesesimp>
@@ -1020,7 +1020,7 @@
         <Polish>5.56mm EPR 50Rnd X15 (IR-DIM every 4)</Polish>
         <Portuguese>5.56mm EPR 50Rnd X15 (IR-DIM every 4)</Portuguese>
         <Russian>5.56mm EPR 50Rnd X15 (IR-DIM every 4)</Russian>
-        <German>5.56mm EPR 50Rnd X15 (IR-DIM every 4)</German>
+        <German>5.56mm EPR 50 Schuss X15 (IR-DIM alle 4)</German>
         <Japanese>5.56mm EPR 50発入り X15 (4発毎にIR-DIM)</Japanese>
         <Korean>5.56mm EPR 50Rnd X15 (IR-DIM every 4)</Korean>
         <Chinesesimp>5.56mm EPR 50Rnd X15 (IR-DIM every 4)</Chinesesimp>
@@ -1035,7 +1035,7 @@
         <Polish>5.56mm EPR 30Rnd PMAG</Polish>
         <Portuguese>5.56mm EPR 30Rnd PMAG</Portuguese>
         <Russian>5.56mm EPR 30Rnd PMAG</Russian>
-        <German>5.56mm EPR 30Rnd PMAG</German>
+        <German>5.56mm EPR 30 Schuss PMAG</German>
         <Japanese>5.56mm EPR 30発入り PMAG</Japanese>
         <Korean>5.56mm EPR 30Rnd PMAG</Korean>
         <Chinesesimp>5.56mm EPR 30Rnd PMAG</Chinesesimp>
@@ -1050,7 +1050,7 @@
         <Polish>5.56mm SOST 30Rnd PMAG</Polish>
         <Portuguese>5.56mm SOST 30Rnd PMAG</Portuguese>
         <Russian>5.56mm SOST 30Rnd PMAG</Russian>
-        <German>5.56mm SOST 30Rnd PMAG</German>
+        <German>5.56mm SOST 30 Schuss PMAG</German>
         <Japanese>5.56mm SOST 30発入り PMAG</Japanese>
         <Korean>5.56mm SOST 30Rnd PMAG</Korean>
         <Chinesesimp>5.56mm SOST 30Rnd PMAG</Chinesesimp>
@@ -1080,7 +1080,7 @@
         <Polish>5.56mm Subsonic 30Rnd PMAG</Polish>
         <Portuguese>5.56mm Subsonic 30Rnd PMAG</Portuguese>
         <Russian>5.56mm Subsonic 30Rnd PMAG</Russian>
-        <German>5.56mm Subsonic 30Rnd PMAG</German>
+        <German>5.56mm Unterschall 30 Schuss PMAG</German>
         <Japanese>5.56mm 亜音速 30発入り PMAG</Japanese>
         <Korean>5.56mm Subsonic 30Rnd PMAG</Korean>
         <Chinesesimp>5.56mm Subsonic 30Rnd PMAG</Chinesesimp>
@@ -1095,7 +1095,7 @@
         <Polish>5.56mm EPR 30Rnd PMAG (Tracers every 4)</Polish>
         <Portuguese>5.56mm EPR 30Rnd PMAG (Tracers every 4)</Portuguese>
         <Russian>5.56mm EPR 30Rnd PMAG (Tracers every 4)</Russian>
-        <German>5.56mm EPR 30Rnd PMAG (Tracers every 4)</German>
+        <German>5.56mm EPR 30 Schuss PMAG (Leuchtspur alle 4)</German>
         <Japanese>5.56mm EPR 30発入り PMAG (4発毎に曳光弾)</Japanese>
         <Korean>5.56mm EPR 30Rnd PMAG (Tracers every 4)</Korean>
         <Chinesesimp>5.56mm EPR 30Rnd PMAG (Tracers every 4)</Chinesesimp>
@@ -1110,7 +1110,7 @@
         <Polish>5.56mm Tracer 30Rnd PMAG</Polish>
         <Portuguese>5.56mm Tracer 30Rnd PMAG</Portuguese>
         <Russian>5.56mm Tracer 30Rnd PMAG</Russian>
-        <German>5.56mm Tracer 30Rnd PMAG</German>
+        <German>5.56mm Leuchtspur 30 Schuss PMAG</German>
         <Japanese>5.56mm 曳光弾 30発入り PMAG</Japanese>
         <Korean>5.56mm Tracer 30Rnd PMAG</Korean>
         <Chinesesimp>5.56mm Tracer 30Rnd PMAG</Chinesesimp>
@@ -1125,7 +1125,7 @@
         <Polish>5.56mm IR-DIM 30Rnd PMAG</Polish>
         <Portuguese>5.56mm IR-DIM 30Rnd PMAG</Portuguese>
         <Russian>5.56mm IR-DIM 30Rnd PMAG</Russian>
-        <German>5.56mm IR-DIM 30Rnd PMAG</German>
+        <German>5.56mm IR-DIM 30 Schuss PMAG</German>
         <Japanese>5.56mm IR-DIM 30発入り PMAG</Japanese>
         <Korean>5.56mm IR-DIM 30Rnd PMAG</Korean>
         <Chinesesimp>5.56mm IR-DIM 30Rnd PMAG</Chinesesimp>
@@ -1140,7 +1140,7 @@
         <Polish>5.56mm EPR 30Rnd PMAG (IR-DIM every 4)</Polish>
         <Portuguese>5.56mm EPR 30Rnd PMAG (IR-DIM every 4)</Portuguese>
         <Russian>5.56mm EPR 30Rnd PMAG (IR-DIM every 4)</Russian>
-        <German>5.56mm EPR 30Rnd PMAG (IR-DIM every 4)</German>
+        <German>5.56mm EPR 30 Schuss PMAG (IR-DIM alle 4)</German>
         <Japanese>5.56mm EPR 30発入り PMAG (4発毎にIR-DIM)</Japanese>
         <Korean>5.56mm EPR 30Rnd PMAG (IR-DIM every 4)</Korean>
         <Chinesesimp>5.56mm EPR 30Rnd PMAG (IR-DIM every 4)</Chinesesimp>
@@ -1155,7 +1155,7 @@
         <Polish>5.56mm EPR 30Rnd STANAG-Heavy</Polish>
         <Portuguese>5.56mm EPR 30Rnd STANAG-Heavy</Portuguese>
         <Russian>5.56mm EPR 30Rnd STANAG-Heavy</Russian>
-        <German>5.56mm EPR 30Rnd STANAG-Heavy</German>
+        <German>5.56mm EPR 30 Schuss STANAG-Heavy</German>
         <Japanese>5.56mm EPR 30発入り STANAGヘビー</Japanese>
         <Korean>5.56mm EPR 30Rnd STANAG-Heavy</Korean>
         <Chinesesimp>5.56mm EPR 30Rnd STANAG-Heavy</Chinesesimp>
@@ -1170,7 +1170,7 @@
         <Polish>5.56mm SOST 30Rnd STANAG-Heavy</Polish>
         <Portuguese>5.56mm SOST 30Rnd STANAG-Heavy</Portuguese>
         <Russian>5.56mm SOST 30Rnd STANAG-Heavy</Russian>
-        <German>5.56mm SOST 30Rnd STANAG-Heavy</German>
+        <German>5.56mm SOST 30 Schuss STANAG-Heavy</German>
         <Japanese>5.56mm SOST 30発入り STANAGヘビー</Japanese>
         <Korean>5.56mm SOST 30Rnd STANAG-Heavy</Korean>
         <Chinesesimp>5.56mm SOST 30Rnd STANAG-Heavy</Chinesesimp>
@@ -1185,7 +1185,7 @@
         <Polish>5.56mm SBLR 30Rnd STANAG-Heavy</Polish>
         <Portuguese>5.56mm SBLR 30Rnd STANAG-Heavy</Portuguese>
         <Russian>5.56mm SBLR 30Rnd STANAG-Heavy</Russian>
-        <German>5.56mm SBLR 30Rnd STANAG-Heavy</German>
+        <German>5.56mm SBLR 30 Schuss STANAG-Heavy</German>
         <Japanese>5.56mm SBLR 30発入り STANAGヘビー</Japanese>
         <Korean>5.56mm SBLR 30Rnd STANAG-Heavy</Korean>
         <Chinesesimp>5.56mm SBLR 30Rnd STANAG-Heavy</Chinesesimp>
@@ -1200,7 +1200,7 @@
         <Polish>5.56mm Subsonic 30Rnd STANAG-Heavy</Polish>
         <Portuguese>5.56mm Subsonic 30Rnd STANAG-Heavy</Portuguese>
         <Russian>5.56mm Subsonic 30Rnd STANAG-Heavy</Russian>
-        <German>5.56mm Subsonic 30Rnd STANAG-Heavy</German>
+        <German>5.56mm Unterschall 30 Schuss STANAG-Heavy</German>
         <Japanese>5.56mm 亜音速 30発入り STANAGヘビー</Japanese>
         <Korean>5.56mm Subsonic 30Rnd STANAG-Heavy</Korean>
         <Chinesesimp>5.56mm Subsonic 30Rnd STANAG-Heavy</Chinesesimp>
@@ -1215,7 +1215,7 @@
         <Polish>5.56mm EPR 30Rnd STANAG-Heavy (Tracers every 4)</Polish>
         <Portuguese>5.56mm EPR 30Rnd STANAG-Heavy (Tracers every 4)</Portuguese>
         <Russian>5.56mm EPR 30Rnd STANAG-Heavy (Tracers every 4)</Russian>
-        <German>5.56mm EPR 30Rnd STANAG-Heavy (Tracers every 4)</German>
+        <German>5.56mm EPR 30 Schuss STANAG-Heavy (Leuchtspur alle 4)</German>
         <Japanese>5.56mm EPR 30発入り STANAGヘビー (4発毎に曳光弾)</Japanese>
         <Korean>5.56mm EPR 30Rnd STANAG-Heavy (Tracers every 4)</Korean>
         <Chinesesimp>5.56mm EPR 30Rnd STANAG-Heavy (Tracers every 4)</Chinesesimp>
@@ -1230,7 +1230,7 @@
         <Polish>5.56mm Tracer 30Rnd STANAG-Heavy</Polish>
         <Portuguese>5.56mm Tracer 30Rnd STANAG-Heavy</Portuguese>
         <Russian>5.56mm Tracer 30Rnd STANAG-Heavy</Russian>
-        <German>5.56mm Tracer 30Rnd STANAG-Heavy</German>
+        <German>5.56mm Leuchtspur 30 Schuss STANAG-Heavy</German>
         <Japanese>5.56mm 曳光弾 30発入り STANAGヘビー</Japanese>
         <Korean>5.56mm Tracer 30Rnd STANAG-Heavy</Korean>
         <Chinesesimp>5.56mm Tracer 30Rnd STANAG-Heavy</Chinesesimp>
@@ -1245,7 +1245,7 @@
         <Polish>5.56mm IR-DIM 30Rnd STANAG-Heavy</Polish>
         <Portuguese>5.56mm IR-DIM 30Rnd STANAG-Heavy</Portuguese>
         <Russian>5.56mm IR-DIM 30Rnd STANAG-Heavy</Russian>
-        <German>5.56mm IR-DIM 30Rnd STANAG-Heavy</German>
+        <German>5.56mm IR-DIM 30 Schuss STANAG-Heavy</German>
         <Japanese>5.56mm IR-DIM 30発入り STANAGヘビー</Japanese>
         <Korean>5.56mm IR-DIM 30Rnd STANAG-Heavy</Korean>
         <Chinesesimp>5.56mm IR-DIM 30Rnd STANAG-Heavy</Chinesesimp>
@@ -1260,7 +1260,7 @@
         <Polish>5.56mm EPR 30Rnd STANAG-Heavy (IR-DIM every 4)</Polish>
         <Portuguese>5.56mm EPR 30Rnd STANAG-Heavy (IR-DIM every 4)</Portuguese>
         <Russian>5.56mm EPR 30Rnd STANAG-Heavy (IR-DIM every 4)</Russian>
-        <German>5.56mm EPR 30Rnd STANAG-Heavy (IR-DIM every 4)</German>
+        <German>5.56mm EPR 30 Schuss STANAG-Heavy (IR-DIM every 4)</German>
         <Japanese>5.56mm EPR 30発入り STANAGヘビー (4発毎にIR-DIM)</Japanese>
         <Korean>5.56mm EPR 30Rnd STANAG-Heavy (IR-DIM every 4)</Korean>
         <Chinesesimp>5.56mm EPR 30Rnd STANAG-Heavy (IR-DIM every 4)</Chinesesimp>
@@ -1275,7 +1275,7 @@
         <Polish>5.56mm EPR 30Rnd Lancer</Polish>
         <Portuguese>5.56mm EPR 30Rnd Lancer</Portuguese>
         <Russian>5.56mm EPR 30Rnd Lancer</Russian>
-        <German>5.56mm EPR 30Rnd Lancer</German>
+        <German>5.56mm EPR 30 Schuss Lancer</German>
         <Japanese>5.56mm EPR 30発入り Lancer</Japanese>
         <Korean>5.56mm EPR 30Rnd Lancer</Korean>
         <Chinesesimp>5.56mm EPR 30Rnd Lancer</Chinesesimp>
@@ -1290,7 +1290,7 @@
         <Polish>5.56mm SOST 30Rnd Lancer</Polish>
         <Portuguese>5.56mm SOST 30Rnd Lancer</Portuguese>
         <Russian>5.56mm SOST 30Rnd Lancer</Russian>
-        <German>5.56mm SOST 30Rnd Lancer</German>
+        <German>5.56mm SOST 30 Schuss Lancer</German>
         <Japanese>5.56mm SOST 30発入り Lancer</Japanese>
         <Korean>5.56mm SOST 30Rnd Lancer</Korean>
         <Chinesesimp>5.56mm SOST 30Rnd Lancer</Chinesesimp>
@@ -1305,7 +1305,7 @@
         <Polish>5.56mm SBLR 30Rnd Lancer</Polish>
         <Portuguese>5.56mm SBLR 30Rnd Lancer</Portuguese>
         <Russian>5.56mm SBLR 30Rnd Lancer</Russian>
-        <German>5.56mm SBLR 30Rnd Lancer</German>
+        <German>5.56mm SBLR 30 Schuss Lancer</German>
         <Japanese>5.56mm SBLR 30発入り Lancer</Japanese>
         <Korean>5.56mm SBLR 30Rnd Lancer</Korean>
         <Chinesesimp>5.56mm SBLR 30Rnd Lancer</Chinesesimp>
@@ -1320,7 +1320,7 @@
         <Polish>5.56mm Subsonic 30Rnd Lancer</Polish>
         <Portuguese>5.56mm Subsonic 30Rnd Lancer</Portuguese>
         <Russian>5.56mm Subsonic 30Rnd Lancer</Russian>
-        <German>5.56mm Subsonic 30Rnd Lancer</German>
+        <German>5.56mm Unterschall 30 Schuss Lancer</German>
         <Japanese>5.56mm 亜音速 30発入り Lancer</Japanese>
         <Korean>5.56mm Subsonic 30Rnd Lancer</Korean>
         <Chinesesimp>5.56mm Subsonic 30Rnd Lancer</Chinesesimp>
@@ -1335,7 +1335,7 @@
         <Polish>5.56mm EPR 30Rnd Lancer (Tracers every 4)</Polish>
         <Portuguese>5.56mm EPR 30Rnd Lancer (Tracers every 4)</Portuguese>
         <Russian>5.56mm EPR 30Rnd Lancer (Tracers every 4)</Russian>
-        <German>5.56mm EPR 30Rnd Lancer (Tracers every 4)</German>
+        <German>5.56mm EPR 30 Schuss Lancer (Leuchtspur alle 4)</German>
         <Japanese>5.56mm EPR 30発入り Lancer (4発毎に曳光弾)</Japanese>
         <Korean>5.56mm EPR 30Rnd Lancer (Tracers every 4)</Korean>
         <Chinesesimp>5.56mm EPR 30Rnd Lancer (Tracers every 4)</Chinesesimp>
@@ -1350,7 +1350,7 @@
         <Polish>5.56mm Tracer 30Rnd Lancer</Polish>
         <Portuguese>5.56mm Tracer 30Rnd Lancer</Portuguese>
         <Russian>5.56mm Tracer 30Rnd Lancer</Russian>
-        <German>5.56mm Tracer 30Rnd Lancer</German>
+        <German>5.56mm Leuchtspur 30 Schuss Lancer</German>
         <Japanese>5.56mm 曳光弾 30発入り Lancer</Japanese>
         <Korean>5.56mm Tracer 30Rnd Lancer</Korean>
         <Chinesesimp>5.56mm Tracer 30Rnd Lancer</Chinesesimp>
@@ -1365,7 +1365,7 @@
         <Polish>5.56mm IR-DIM 30Rnd Lancer</Polish>
         <Portuguese>5.56mm IR-DIM 30Rnd Lancer</Portuguese>
         <Russian>5.56mm IR-DIM 30Rnd Lancer</Russian>
-        <German>5.56mm IR-DIM 30Rnd Lancer</German>
+        <German>5.56mm IR-DIM 30 Schuss Lancer</German>
         <Japanese>5.56mm IR-DIM 30発入り ランサー</Japanese>
         <Korean>5.56mm IR-DIM 30Rnd Lancer</Korean>
         <Chinesesimp>5.56mm IR-DIM 30Rnd Lancer</Chinesesimp>
@@ -1380,7 +1380,7 @@
         <Polish>5.56mm EPR 30Rnd Lancer (IR-DIM every 4)</Polish>
         <Portuguese>5.56mm EPR 30Rnd Lancer (IR-DIM every 4)</Portuguese>
         <Russian>5.56mm EPR 30Rnd Lancer (IR-DIM every 4)</Russian>
-        <German>5.56mm EPR 30Rnd Lancer (IR-DIM every 4)</German>
+        <German>5.56mm EPR 30 Schuss Lancer (IR-DIM alle 4)</German>
         <Japanese>5.56mm EPR 30発入り Lancer (4発毎にIR-DIM)</Japanese>
         <Korean>5.56mm EPR 30Rnd Lancer (IR-DIM every 4)</Korean>
         <Chinesesimp>5.56mm EPR 30Rnd Lancer (IR-DIM every 4)</Chinesesimp>
@@ -1395,7 +1395,7 @@
         <Polish>5.56mm EPR 30Rnd EMAG</Polish>
         <Portuguese>5.56mm EPR 30Rnd EMAG</Portuguese>
         <Russian>5.56mm EPR 30Rnd EMAG</Russian>
-        <German>5.56mm EPR 30Rnd EMAG</German>
+        <German>5.56mm EPR 30 Schuss EMAG</German>
         <Japanese>5.56mm EPR 30発入り EMAG</Japanese>
         <Korean>5.56mm EPR 30Rnd EMAG</Korean>
         <Chinesesimp>5.56mm EPR 30Rnd EMAG</Chinesesimp>
@@ -1410,7 +1410,7 @@
         <Polish>5.56mm SOST 30Rnd EMAG</Polish>
         <Portuguese>5.56mm SOST 30Rnd EMAG</Portuguese>
         <Russian>5.56mm SOST 30Rnd EMAG</Russian>
-        <German>5.56mm SOST 30Rnd EMAG</German>
+        <German>5.56mm SOST 30 Schuss EMAG</German>
         <Japanese>5.56mm SOST 30発入り EMAG</Japanese>
         <Korean>5.56mm SOST 30Rnd EMAG</Korean>
         <Chinesesimp>5.56mm SOST 30Rnd EMAG</Chinesesimp>
@@ -1425,7 +1425,7 @@
         <Polish>5.56mm SBLR 30Rnd EMAG</Polish>
         <Portuguese>5.56mm SBLR 30Rnd EMAG</Portuguese>
         <Russian>5.56mm SBLR 30Rnd EMAG</Russian>
-        <German>5.56mm SBLR 30Rnd EMAG</German>
+        <German>5.56mm SBLR 30 Schuss EMAG</German>
         <Japanese>5.56mm SBLR 30発入り EMAG</Japanese>
         <Korean>5.56mm SBLR 30Rnd EMAG</Korean>
         <Chinesesimp>5.56mm SBLR 30Rnd EMAG</Chinesesimp>
@@ -1440,7 +1440,7 @@
         <Polish>5.56mm Subsonic 30Rnd EMAG</Polish>
         <Portuguese>5.56mm Subsonic 30Rnd EMAG</Portuguese>
         <Russian>5.56mm Subsonic 30Rnd EMAG</Russian>
-        <German>5.56mm Subsonic 30Rnd EMAG</German>
+        <German>5.56mm Unterschall 30 Schuss EMAG</German>
         <Japanese>5.56mm 亜音速 30発入り EMAG</Japanese>
         <Korean>5.56mm Subsonic 30Rnd EMAG</Korean>
         <Chinesesimp>5.56mm Subsonic 30Rnd EMAG</Chinesesimp>
@@ -1455,7 +1455,7 @@
         <Polish>5.56mm EPR 30Rnd EMAG (Tracers every 4)</Polish>
         <Portuguese>5.56mm EPR 30Rnd EMAG (Tracers every 4)</Portuguese>
         <Russian>5.56mm EPR 30Rnd EMAG (Tracers every 4)</Russian>
-        <German>5.56mm EPR 30Rnd EMAG (Tracers every 4)</German>
+        <German>5.56mm EPR 30 Schuss EMAG (Leuchtspur alle 4)</German>
         <Japanese>5.56mm EPR 30発入り EMAG (4発毎に曳光弾)</Japanese>
         <Korean>5.56mm EPR 30Rnd EMAG (Tracers every 4)</Korean>
         <Chinesesimp>5.56mm EPR 30Rnd EMAG (Tracers every 4)</Chinesesimp>
@@ -1470,7 +1470,7 @@
         <Polish>5.56mm Tracer 30Rnd EMAG</Polish>
         <Portuguese>5.56mm Tracer 30Rnd EMAG</Portuguese>
         <Russian>5.56mm Tracer 30Rnd EMAG</Russian>
-        <German>5.56mm Tracer 30Rnd EMAG</German>
+        <German>5.56mm Leuchtspur 30 Schuss EMAG</German>
         <Japanese>5.56mm 曳光弾 30発入り EMAG</Japanese>
         <Korean>5.56mm Tracer 30Rnd EMAG</Korean>
         <Chinesesimp>5.56mm Tracer 30Rnd EMAG</Chinesesimp>
@@ -1485,7 +1485,7 @@
         <Polish>5.56mm IR-DIM 30Rnd EMAG</Polish>
         <Portuguese>5.56mm IR-DIM 30Rnd EMAG</Portuguese>
         <Russian>5.56mm IR-DIM 30Rnd EMAG</Russian>
-        <German>5.56mm IR-DIM 30Rnd EMAG</German>
+        <German>5.56mm IR-DIM 30 Schuss EMAG</German>
         <Japanese>5.56mm IR-DIM 30発入り EMAG</Japanese>
         <Korean>5.56mm IR-DIM 30Rnd EMAG</Korean>
         <Chinesesimp>5.56mm IR-DIM 30Rnd EMAG</Chinesesimp>
@@ -1500,7 +1500,7 @@
         <Polish>5.56mm EPR 30Rnd EMAG (IR-DIM every 4)</Polish>
         <Portuguese>5.56mm EPR 30Rnd EMAG (IR-DIM every 4)</Portuguese>
         <Russian>5.56mm EPR 30Rnd EMAG (IR-DIM every 4)</Russian>
-        <German>5.56mm EPR 30Rnd EMAG (IR-DIM every 4)</German>
+        <German>5.56mm EPR 30 Schuss EMAG (IR-DIM alle 4)</German>
         <Japanese>5.56mm EPR 30発入り EMAG (4発毎にIR-DIM)</Japanese>
         <Korean>5.56mm EPR 30Rnd EMAG (IR-DIM every 4)</Korean>
         <Chinesesimp>5.56mm EPR 30Rnd EMAG (IR-DIM every 4)</Chinesesimp>
@@ -1515,7 +1515,7 @@
         <Polish>5.45mm FMJ 30Rnd AK Magazine</Polish>
         <Portuguese>5.45mm FMJ 30Rnd AK Magazine</Portuguese>
         <Russian>5.45mm FMJ 30Rnd AK Magazine</Russian>
-        <German>5.45mm FMJ 30Rnd AK Magazine</German>
+        <German>5.45mm FMJ 30 Schuss AK-Magazin</German>
         <Japanese>5.45mm FMJ 30発入り AK マガジン</Japanese>
         <Korean>5.45mm FMJ 30Rnd AK Magazine</Korean>
         <Chinesesimp>5.45mm FMJ 30Rnd AK Magazine</Chinesesimp>
@@ -1530,7 +1530,7 @@
         <Polish>5.45mm Subsonic 30Rnd AK Magazine</Polish>
         <Portuguese>5.45mm Subsonic 30Rnd AK Magazine</Portuguese>
         <Russian>5.45mm Subsonic 30Rnd AK Magazine</Russian>
-        <German>5.45mm Subsonic 30Rnd AK Magazine</German>
+        <German>5.45mm Unterschall 30 Schuss AK-Magazin</German>
         <Japanese>5.45mm 亜音速 30発入り AK マガジン</Japanese>
         <Korean>5.45mm Subsonic 30Rnd AK Magazine</Korean>
         <Chinesesimp>5.45mm Subsonic 30Rnd AK Magazine</Chinesesimp>
@@ -1545,7 +1545,7 @@
         <Polish>5.45mm Tracer 30Rnd AK Magazine</Polish>
         <Portuguese>5.45mm Tracer 30Rnd AK Magazine</Portuguese>
         <Russian>5.45mm Tracer 30Rnd AK Magazine</Russian>
-        <German>5.45mm Tracer 30Rnd AK Magazine</German>
+        <German>5.45mm Leuchtspur 30 Schuss AK-Magazin</German>
         <Japanese>5.45mm 曳光弾 30発入り AK マガジン</Japanese>
         <Korean>5.45mm Tracer 30Rnd AK Magazine</Korean>
         <Chinesesimp>5.45mm Tracer 30Rnd AK Magazine</Chinesesimp>
@@ -1560,7 +1560,7 @@
         <Polish>5.45mm FMJ 30Rnd AK Magazine (Tracers Every 3)</Polish>
         <Portuguese>5.45mm FMJ 30Rnd AK Magazine (Tracers Every 3)</Portuguese>
         <Russian>5.45mm FMJ 30Rnd AK Magazine (Tracers Every 3)</Russian>
-        <German>5.45mm FMJ 30Rnd AK Magazine (Tracers Every 3)</German>
+        <German>5.45mm FMJ 30 Schuss AK-Magazin (Leuchtspur alle 3)</German>
         <Japanese>5.45mm FMJ 30発入り AK マガジン (3発毎に曳光弾)</Japanese>
         <Korean>5.45mm FMJ 30Rnd AK Magazine (Tracers Every 3)</Korean>
         <Chinesesimp>5.45mm FMJ 30Rnd AK Magazine (Tracers Every 3)</Chinesesimp>
@@ -1575,7 +1575,7 @@
         <Polish>5.45mm EPR 30Rnd AK Magazine (Tracers Every 3)</Polish>
         <Portuguese>5.45mm EPR 30Rnd AK Magazine (Tracers Every 3)</Portuguese>
         <Russian>5.45mm EPR 30Rnd AK Magazine (Tracers Every 3)</Russian>
-        <German>5.45mm EPR 30Rnd AK Magazine (Tracers Every 3)</German>
+        <German>5.45mm EPR 30 Schuss AK-Magazin (Leuchtspur alle 3)</German>
         <Japanese>5.45mm EPR 30発入り AK マガジン (3発毎に曳光弾)</Japanese>
         <Korean>5.45mm EPR 30Rnd AK Magazine (Tracers Every 3)</Korean>
         <Chinesesimp>5.45mm EPR 30Rnd AK Magazine (Tracers Every 3)</Chinesesimp>
@@ -1590,7 +1590,7 @@
         <Polish>5.45mm FMJ 30Rnd Plum AK Magazine</Polish>
         <Portuguese>5.45mm FMJ 30Rnd Plum AK Magazine</Portuguese>
         <Russian>5.45mm FMJ 30Rnd Plum AK Magazine</Russian>
-        <German>5.45mm FMJ 30Rnd Plum AK Magazine</German>
+        <German>5.45mm FMJ 30 Schuss Pflaumenfarbenes AK-Magazin</German>
         <Japanese>5.45mm FMJ 30発入り プラム AK マガジン</Japanese>
         <Korean>5.45mm FMJ 30Rnd Plum AK Magazine</Korean>
         <Chinesesimp>5.45mm FMJ 30Rnd Plum AK Magazine</Chinesesimp>
@@ -1605,7 +1605,7 @@
         <Polish>5.45mm Subsonic 30Rnd Plum AK Magazine</Polish>
         <Portuguese>5.45mm Subsonic 30Rnd Plum AK Magazine</Portuguese>
         <Russian>5.45mm Subsonic 30Rnd Plum AK Magazine</Russian>
-        <German>5.45mm Subsonic 30Rnd Plum AK Magazine</German>
+        <German>5.45mm Unterschall 30 Schuss Pflaumenfarbenes AK-Magazin</German>
         <Japanese>5.45mm 亜音速 30発入り プラム AK マガジン</Japanese>
         <Korean>5.45mm Subsonic 30Rnd Plum AK Magazine</Korean>
         <Chinesesimp>5.45mm Subsonic 30Rnd Plum AK Magazine</Chinesesimp>
@@ -1620,7 +1620,7 @@
         <Polish>5.45mm Tracer 30Rnd Plum AK Magazine</Polish>
         <Portuguese>5.45mm Tracer 30Rnd Plum AK Magazine</Portuguese>
         <Russian>5.45mm Tracer 30Rnd Plum AK Magazine</Russian>
-        <German>5.45mm Tracer 30Rnd Plum AK Magazine</German>
+        <German>5.45mm Leuchtspur 30 Schuss Pflaumenfarbenes AK-Magazin</German>
         <Japanese>5.45mm 曳光弾 30発入り プラム AK マガジン</Japanese>
         <Korean>5.45mm Tracer 30Rnd Plum AK Magazine</Korean>
         <Chinesesimp>5.45mm Tracer 30Rnd Plum AK Magazine</Chinesesimp>
@@ -1635,7 +1635,7 @@
         <Polish>5.45mm FMJ 30Rnd Plum AK Magazine (Tracers Every 3)</Polish>
         <Portuguese>5.45mm FMJ 30Rnd Plum AK Magazine (Tracers Every 3)</Portuguese>
         <Russian>5.45mm FMJ 30Rnd Plum AK Magazine (Tracers Every 3)</Russian>
-        <German>5.45mm FMJ 30Rnd Plum AK Magazine (Tracers Every 3)</German>
+        <German>5.45mm FMJ 30Rnd Pflaumenfarbenes AK-Magazin (Leuchtspur alle 3)</German>
         <Japanese>5.45mm FMJ 30発入り プラム AK マガジン (3発毎に曳光弾)</Japanese>
         <Korean>5.45mm FMJ 30Rnd Plum AK Magazine (Tracers Every 3)</Korean>
         <Chinesesimp>5.45mm FMJ 30Rnd Plum AK Magazine (Tracers Every 3)</Chinesesimp>
@@ -1650,7 +1650,7 @@
         <Polish>5.45mm EPR 30Rnd Plum AK Magazine (Tracers Every 3)</Polish>
         <Portuguese>5.45mm EPR 30Rnd Plum AK Magazine (Tracers Every 3)</Portuguese>
         <Russian>5.45mm EPR 30Rnd Plum AK Magazine (Tracers Every 3)</Russian>
-        <German>5.45mm EPR 30Rnd Plum AK Magazine (Tracers Every 3)</German>
+        <German>5.45mm EPR 30 Schuss Pflaumenfarbenes AK-Magazin (Leuchtspur alle 3)</German>
         <Japanese>5.45mm EPR 30発入り プラム AK マガジン (3発毎に曳光弾)</Japanese>
         <Korean>5.45mm EPR 30Rnd Plum AK Magazine (Tracers Every 3)</Korean>
         <Chinesesimp>5.45mm EPR 30Rnd Plum AK Magazine (Tracers Every 3)</Chinesesimp>
@@ -1665,7 +1665,7 @@
         <Polish>5.45mm FMJ 30Rnd Black AK Magazine</Polish>
         <Portuguese>5.45mm FMJ 30Rnd Black AK Magazine</Portuguese>
         <Russian>5.45mm FMJ 30Rnd Black AK Magazine</Russian>
-        <German>5.45mm FMJ 30Rnd Black AK Magazine</German>
+        <German>5.45mm FMJ 30 Schuss Schwarzes AK-Magazin</German>
         <Japanese>5.45mm FMJ 30発入り ブラック AK マガジン</Japanese>
         <Korean>5.45mm FMJ 30Rnd Black AK Magazine</Korean>
         <Chinesesimp>5.45mm FMJ 30Rnd Black AK Magazine</Chinesesimp>
@@ -1680,7 +1680,7 @@
         <Polish>5.45mm Subsonic 30Rnd Black AK Magazine</Polish>
         <Portuguese>5.45mm Subsonic 30Rnd Black AK Magazine</Portuguese>
         <Russian>5.45mm Subsonic 30Rnd Black AK Magazine</Russian>
-        <German>5.45mm Subsonic 30Rnd Black AK Magazine</German>
+        <German>5.45mm Unterschall 30 Schuss Schwarzes AK-Magazin</German>
         <Japanese>5.45mm 亜音速 30発入り ブラック AK マガジン</Japanese>
         <Korean>5.45mm Subsonic 30Rnd Black AK Magazine</Korean>
         <Chinesesimp>5.45mm Subsonic 30Rnd Black AK Magazine</Chinesesimp>
@@ -1695,7 +1695,7 @@
         <Polish>5.45mm Tracer 30Rnd Black AK Magazine</Polish>
         <Portuguese>5.45mm Tracer 30Rnd Black AK Magazine</Portuguese>
         <Russian>5.45mm Tracer 30Rnd Black AK Magazine</Russian>
-        <German>5.45mm Tracer 30Rnd Black AK Magazine</German>
+        <German>5.45mm Tracer 30 Schuss Schwarzes AK-Magazin</German>
         <Japanese>5.45mm 曳光弾 30発入り ブラック AK マガジン</Japanese>
         <Korean>5.45mm Tracer 30Rnd Black AK Magazine</Korean>
         <Chinesesimp>5.45mm Tracer 30Rnd Black AK Magazine</Chinesesimp>
@@ -1710,7 +1710,7 @@
         <Polish>5.45mm FMJ 30Rnd Black AK Magazine (Tracers Every 3)</Polish>
         <Portuguese>5.45mm FMJ 30Rnd Black AK Magazine (Tracers Every 3)</Portuguese>
         <Russian>5.45mm FMJ 30Rnd Black AK Magazine (Tracers Every 3)</Russian>
-        <German>5.45mm FMJ 30Rnd Black AK Magazine (Tracers Every 3)</German>
+        <German>5.45mm FMJ 30 Schuss Schwarzes AK Magazine (Leuchtspur alle 3)</German>
         <Japanese>5.45mm FMJ 30発入り ブラック AK マガジン (3発毎に曳光弾)</Japanese>
         <Korean>5.45mm FMJ 30Rnd Black AK Magazine (Tracers Every 3)</Korean>
         <Chinesesimp>5.45mm FMJ 30Rnd Black AK Magazine (Tracers Every 3)</Chinesesimp>
@@ -1725,7 +1725,7 @@
         <Polish>5.45mm EPR 30Rnd Black AK Magazine (Tracers Every 3)</Polish>
         <Portuguese>5.45mm EPR 30Rnd Black AK Magazine (Tracers Every 3)</Portuguese>
         <Russian>5.45mm EPR 30Rnd Black AK Magazine (Tracers Every 3)</Russian>
-        <German>5.45mm EPR 30Rnd Black AK Magazine (Tracers Every 3)</German>
+        <German>5.45mm EPR 30 Schuss Schwarzes AK Magazine (Leuchtspur alle 3)</German>
         <Japanese>5.45mm EPR 30発入り ブラック AK マガジン (3発毎に曳光弾)</Japanese>
         <Korean>5.45mm EPR 30Rnd Black AK Magazine (Tracers Every 3)</Korean>
         <Chinesesimp>5.45mm EPR 30Rnd Black AK Magazine (Tracers Every 3)</Chinesesimp>
@@ -1740,7 +1740,7 @@
         <Polish>5.45mm FMJ 45Rnd RPK74M Magazine</Polish>
         <Portuguese>5.45mm FMJ 45Rnd RPK74M Magazine</Portuguese>
         <Russian>5.45mm FMJ 45Rnd RPK74M Magazine</Russian>
-        <German>5.45mm FMJ 45Rnd RPK74M Magazine</German>
+        <German>5.45mm FMJ 45 Schuss RPK74M-Magazin</German>
         <Japanese>5.45mm FMJ 45発入り RPK74M マガジン</Japanese>
         <Korean>5.45mm FMJ 45Rnd RPK74M Magazine</Korean>
         <Chinesesimp>5.45mm FMJ 45Rnd RPK74M Magazine</Chinesesimp>
@@ -1755,7 +1755,7 @@
         <Polish>5.45mm Tracer 45Rnd RPK74M Magazine</Polish>
         <Portuguese>5.45mm Tracer 45Rnd RPK74M Magazine</Portuguese>
         <Russian>5.45mm Tracer 45Rnd RPK74M Magazine</Russian>
-        <German>5.45mm Tracer 45Rnd RPK74M Magazine</German>
+        <German>5.45mm Tracer 45 Schuss RPK74M-Magazin</German>
         <Japanese>5.45mm 曳光弾 45発入り RPK74M マガジン</Japanese>
         <Korean>5.45mm Tracer 45Rnd RPK74M Magazine</Korean>
         <Chinesesimp>5.45mm Tracer 45Rnd RPK74M Magazine</Chinesesimp>
@@ -1770,7 +1770,7 @@
         <Polish>5.45mm FMJ 45Rnd RPK74M Magazine (Tracers Every 3)</Polish>
         <Portuguese>5.45mm FMJ 45Rnd RPK74M Magazine (Tracers Every 3)</Portuguese>
         <Russian>5.45mm FMJ 45Rnd RPK74M Magazine (Tracers Every 3)</Russian>
-        <German>5.45mm FMJ 45Rnd RPK74M Magazine (Tracers Every 3)</German>
+        <German>5.45mm FMJ 45 Schuss RPK74M-Magazin (Leuchtspur alle 3)</German>
         <Japanese>5.45mm FMJ 45発入り RPK74M マガジン (3発毎に曳光弾)</Japanese>
         <Korean>5.45mm FMJ 45Rnd RPK74M Magazine (Tracers Every 3)</Korean>
         <Chinesesimp>5.45mm FMJ 45Rnd RPK74M Magazine (Tracers Every 3)</Chinesesimp>
@@ -1785,7 +1785,7 @@
         <Polish>5.45mm EPR 45Rnd RPK74M Magazine (Tracers Every 3)</Polish>
         <Portuguese>5.45mm EPR 45Rnd RPK74M Magazine (Tracers Every 3)</Portuguese>
         <Russian>5.45mm EPR 45Rnd RPK74M Magazine (Tracers Every 3)</Russian>
-        <German>5.45mm EPR 45Rnd RPK74M Magazine (Tracers Every 3)</German>
+        <German>5.45mm EPR 45 Schuss RPK74M-Magazin (Leuchtspur alle 3)</German>
         <Japanese>5.45mm EPR 45発入り RPK74M マガジン (3発毎に曳光弾)</Japanese>
         <Korean>5.45mm EPR 45Rnd RPK74M Magazine (Tracers Every 3)</Korean>
         <Chinesesimp>5.45mm EPR 45Rnd RPK74M Magazine (Tracers Every 3)</Chinesesimp>
@@ -1800,7 +1800,7 @@
         <Polish>5.45mm FMJ 45Rnd RPK74M Magazine</Polish>
         <Portuguese>5.45mm FMJ 45Rnd RPK74M Magazine</Portuguese>
         <Russian>5.45mm FMJ 45Rnd RPK74M Magazine</Russian>
-        <German>5.45mm FMJ 45Rnd RPK74M Magazine</German>
+        <German>5.45mm FMJ 45 Schuss RPK74M-Magazin</German>
         <Japanese>5.45mm FMJ 45発入り RPK74M マガジン</Japanese>
         <Korean>5.45mm FMJ 45Rnd RPK74M Magazine</Korean>
         <Chinesesimp>5.45mm FMJ 45Rnd RPK74M Magazine</Chinesesimp>
@@ -1815,7 +1815,7 @@
         <Polish>5.45mm Tracer 45Rnd RPK74M Magazine</Polish>
         <Portuguese>5.45mm Tracer 45Rnd RPK74M Magazine</Portuguese>
         <Russian>5.45mm Tracer 45Rnd RPK74M Magazine</Russian>
-        <German>5.45mm Tracer 45Rnd RPK74M Magazine</German>
+        <German>5.45mm Leuchtspur 45 Schuss RPK74M-Magazin</German>
         <Japanese>5.45mm 曳光弾 45発入り RPK74M マガジン</Japanese>
         <Korean>5.45mm Tracer 45Rnd RPK74M Magazine</Korean>
         <Chinesesimp>5.45mm Tracer 45Rnd RPK74M Magazine</Chinesesimp>
@@ -1830,7 +1830,7 @@
         <Polish>5.45mm FMJ 45Rnd RPK74M Magazine (Tracers Every 3)</Polish>
         <Portuguese>5.45mm FMJ 45Rnd RPK74M Magazine (Tracers Every 3)</Portuguese>
         <Russian>5.45mm FMJ 45Rnd RPK74M Magazine (Tracers Every 3)</Russian>
-        <German>5.45mm FMJ 45Rnd RPK74M Magazine (Tracers Every 3)</German>
+        <German>5.45mm FMJ 45 Schuss RPK74M-Magazin (Leuchtspur alle 3)</German>
         <Japanese>5.45mm FMJ 45発入り RPK74M マガジン (3発毎に曳光弾)</Japanese>
         <Korean>5.45mm FMJ 45Rnd RPK74M Magazine (Tracers Every 3)</Korean>
         <Chinesesimp>5.45mm FMJ 45Rnd RPK74M Magazine (Tracers Every 3)</Chinesesimp>
@@ -1845,7 +1845,7 @@
         <Polish>5.45mm EPR 45Rnd RPK74M Magazine (Tracers Every 3)</Polish>
         <Portuguese>5.45mm EPR 45Rnd RPK74M Magazine (Tracers Every 3)</Portuguese>
         <Russian>5.45mm EPR 45Rnd RPK74M Magazine (Tracers Every 3)</Russian>
-        <German>5.45mm EPR 45Rnd RPK74M Magazine (Tracers Every 3)</German>
+        <German>5.45mm EPR 45 Schuss RPK74M-Magazin (Leuchtspur alle 3)</German>
         <Japanese>5.45mm EPR 45発入り RPK74M マガジン (3発毎に曳光弾)</Japanese>
         <Korean>5.45mm EPR 45Rnd RPK74M Magazine (Tracers Every 3)</Korean>
         <Chinesesimp>5.45mm EPR 45Rnd RPK74M Magazine (Tracers Every 3)</Chinesesimp>
@@ -1860,7 +1860,7 @@
         <Polish>5.45mm FMJ 60Rnd RPK Magazine</Polish>
         <Portuguese>5.45mm FMJ 60Rnd RPK Magazine</Portuguese>
         <Russian>5.45mm FMJ 60Rnd RPK Magazine</Russian>
-        <German>5.45mm FMJ 60Rnd RPK Magazine</German>
+        <German>5.45mm FMJ 60 Schuss RPK-Magazin</German>
         <Japanese>5.45mm FMJ 60発入り RPK マガジン</Japanese>
         <Korean>5.45mm FMJ 60Rnd RPK Magazine</Korean>
         <Chinesesimp>5.45mm FMJ 60Rnd RPK Magazine</Chinesesimp>
@@ -1875,7 +1875,7 @@
         <Polish>5.45mm Tracer 60Rnd RPK Magazine</Polish>
         <Portuguese>5.45mm Tracer 60Rnd RPK Magazine</Portuguese>
         <Russian>5.45mm Tracer 60Rnd RPK Magazine</Russian>
-        <German>5.45mm Tracer 60Rnd RPK Magazine</German>
+        <German>5.45mm Leuchtspur 60 Schuss RPK-Magazin</German>
         <Japanese>5.45mm 曳光弾 60発入り RPK マガジン</Japanese>
         <Korean>5.45mm Tracer 60Rnd RPK Magazine</Korean>
         <Chinesesimp>5.45mm Tracer 60Rnd RPK Magazine</Chinesesimp>
@@ -1890,7 +1890,7 @@
         <Polish>5.45mm FMJ 60Rnd RPK Magazine (Tracers Every 3)</Polish>
         <Portuguese>5.45mm FMJ 60Rnd RPK Magazine (Tracers Every 3)</Portuguese>
         <Russian>5.45mm FMJ 60Rnd RPK Magazine (Tracers Every 3)</Russian>
-        <German>5.45mm FMJ 60Rnd RPK Magazine (Tracers Every 3)</German>
+        <German>5.45mm FMJ 60 Schuss RPK-Magazin (Leuchtspur alle 3)</German>
         <Japanese>5.45mm FMJ 60発入り RPK マガジン (3発毎に曳光弾)</Japanese>
         <Korean>5.45mm FMJ 60Rnd RPK Magazine (Tracers Every 3)</Korean>
         <Chinesesimp>5.45mm FMJ 60Rnd RPK Magazine (Tracers Every 3)</Chinesesimp>
@@ -1905,7 +1905,7 @@
         <Polish>5.45mm EPR 60Rnd RPK Magazine (Tracers Every 3)</Polish>
         <Portuguese>5.45mm EPR 60Rnd RPK Magazine (Tracers Every 3)</Portuguese>
         <Russian>5.45mm EPR 60Rnd RPK Magazine (Tracers Every 3)</Russian>
-        <German>5.45mm EPR 60Rnd RPK Magazine (Tracers Every 3)</German>
+        <German>5.45mm EPR 60 Schuss RPK-Magazin (Leuchtspur alle 3)</German>
         <Japanese>5.45mm EPR 60発入り RPK マガジン (3発毎に曳光弾)</Japanese>
         <Korean>5.45mm EPR 60Rnd RPK Magazine (Tracers Every 3)</Korean>
         <Chinesesimp>5.45mm EPR 60Rnd RPK Magazine (Tracers Every 3)</Chinesesimp>
@@ -1920,7 +1920,7 @@
         <Polish>7.62mm FMJ 30Rnd AK Magazine</Polish>
         <Portuguese>7.62mm FMJ 30Rnd AK Magazine</Portuguese>
         <Russian>7.62mm FMJ 30Rnd AK Magazine</Russian>
-        <German>7.62mm FMJ 30Rnd AK Magazine</German>
+        <German>7.62mm FMJ 30 Schuss AK-Magazin</German>
         <Japanese>7.62mm FMJ 30発入り AK マガジン</Japanese>
         <Korean>7.62mm FMJ 30Rnd AK Magazine</Korean>
         <Chinesesimp>7.62mm FMJ 30Rnd AK Magazine</Chinesesimp>
@@ -1935,7 +1935,7 @@
         <Polish>7.62mm Tracer 30Rnd AK Magazine</Polish>
         <Portuguese>7.62mm Tracer 30Rnd AK Magazine</Portuguese>
         <Russian>7.62mm Tracer 30Rnd AK Magazine</Russian>
-        <German>7.62mm Tracer 30Rnd AK Magazine</German>
+        <German>7.62mm Leuchtspur 30 Schuss AK-Magazin</German>
         <Japanese>7.62mm 曳光弾 30発入り AK マガジン</Japanese>
         <Korean>7.62mm Tracer 30Rnd AK Magazine</Korean>
         <Chinesesimp>7.62mm Tracer 30Rnd AK Magazine</Chinesesimp>
@@ -1950,7 +1950,7 @@
         <Polish>7.62mm FMJ 30Rnd AK Magazine (Tracers Every 3)</Polish>
         <Portuguese>7.62mm FMJ 30Rnd AK Magazine (Tracers Every 3)</Portuguese>
         <Russian>7.62mm FMJ 30Rnd AK Magazine (Tracers Every 3)</Russian>
-        <German>7.62mm FMJ 30Rnd AK Magazine (Tracers Every 3)</German>
+        <German>7.62mm FMJ 30 Schuss AK-Magazin (Leuchtspur alle 3)</German>
         <Japanese>7.62mm FMJ 30発入り AK マガジン (3発毎に曳光弾)</Japanese>
         <Korean>7.62mm FMJ 30Rnd AK Magazine (Tracers Every 3)</Korean>
         <Chinesesimp>7.62mm FMJ 30Rnd AK Magazine (Tracers Every 3)</Chinesesimp>
@@ -1965,7 +1965,7 @@
         <Polish>7.62mm AP 30Rnd AK Magazine</Polish>
         <Portuguese>7.62mm AP 30Rnd AK Magazine</Portuguese>
         <Russian>7.62mm AP 30Rnd AK Magazine</Russian>
-        <German>7.62mm AP 30Rnd AK Magazine</German>
+        <German>7.62mm AP 30 Schuss AK-Magazin</German>
         <Japanese>7.62mm AP 30発入り AK マガジン</Japanese>
         <Korean>7.62mm AP 30Rnd AK Magazine</Korean>
         <Chinesesimp>7.62mm AP 30Rnd AK Magazine</Chinesesimp>
@@ -1980,7 +1980,7 @@
         <Polish>7.62mm Subsonic 30Rnd AK Magazine</Polish>
         <Portuguese>7.62mm Subsonic 30Rnd AK Magazine</Portuguese>
         <Russian>7.62mm Subsonic 30Rnd AK Magazine</Russian>
-        <German>7.62mm Subsonic 30Rnd AK Magazine</German>
+        <German>7.62mm Unterschall 30 Schuss AK-Magazin</German>
         <Japanese>7.62mm 亜音速 30発入り AK マガジン</Japanese>
         <Korean>7.62mm Subsonic 30Rnd AK Magazine</Korean>
         <Chinesesimp>7.62mm Subsonic 30Rnd AK Magazine</Chinesesimp>
@@ -1995,7 +1995,7 @@
         <Polish>7.62mm FMJ 30Rnd 6L10 AK Magazine</Polish>
         <Portuguese>7.62mm FMJ 30Rnd 6L10 AK Magazine</Portuguese>
         <Russian>7.62mm FMJ 30Rnd 6L10 AK Magazine</Russian>
-        <German>7.62mm FMJ 30Rnd 6L10 AK Magazine</German>
+        <German>7.62mm FMJ 30 Schuss 6L10 AK-Magazin</German>
         <Japanese>7.62mm FMJ 30発入り 6L10 AK マガジン</Japanese>
         <Korean>7.62mm FMJ 30Rnd 6L10 AK Magazine</Korean>
         <Chinesesimp>7.62mm FMJ 30Rnd 6L10 AK Magazine</Chinesesimp>


### PR DESCRIPTION
When merged, this PR will:
- Rename VOG smoke magazines from "white smoke (color)" to "smoke color" in all languages but Japanese (where it was already fixed)
- Add German translation to the Core stringtable

Not sure how far I wanna go with this.  99.9% of my contact with military stuff is through pop culture in English, the magazine name structure doesn't lend itself to short phrasing ("Sandfarbenes PMAG" vs "PMAG (Sand)", and I've gotten to a point I already touched in a separate PR and I don't know how that'll work out merging in the GitHub webclient.

Might actually just revert the German stuff entirely.