### PR TITLE
Small Mass, Ballistics, Naming, Recoil Fixes

### DIFF
--- a/Compatibility/hlc_rhs_compat_CORE/config.cpp
+++ b/Compatibility/hlc_rhs_compat_CORE/config.cpp
@@ -1,6 +1,6 @@
 #include "\hlc_core\script_macros.hpp"
 
-class CfgPatches 
+class CfgPatches
 {
 	class HLC_COMPAT_RHS_CORE
 	{
@@ -20,4 +20,70 @@ class CfgWeapons
     class UGL_F : GrenadeLauncher {
         magazines[] += { __40MM_M203_RHS_GRENADES };
     };
+};
+class UnderBarrelSlot;
+class nia_rifle_grips_slot: UnderBarrelSlot
+{
+	displayName = "Gripod slot";
+	class compatibleItems
+	{
+		rhsusf_acc_grip1 = 1;
+		rhsusf_acc_grip2 = 1;
+		rhsusf_acc_grip2_tan = 1;
+		rhsusf_acc_grip2_wd = 1;
+		rhsusf_acc_grip3 = 1;
+		rhsusf_acc_grip3_tan = 1;
+		rhs_acc_grip_rk2 = 1;
+		rhs_acc_grip_rk6 = 1;
+		rhs_acc_grip_ffg2 = 1;
+		rhsusf_acc_rvg_blk = 1;
+		rhsusf_acc_rvg_de = 1;
+		rhsusf_acc_tacsac_blk = 1;
+		rhsusf_acc_tacsac_tan = 1;
+		rhsusf_acc_tacsac_blue = 1;
+		rhsusf_acc_tdstubby_blk = 1;
+		rhsusf_acc_tdstubby_tan = 1;
+		rhsusf_acc_kac_grip = 1;
+	};
+};
+class asdg_SlotInfo;
+class asdg_UnderSlot: asdg_SlotInfo
+{
+	class compatibleItems{};
+};
+class nia_rifle_bipodsgrips_slot: asdg_UnderSlot
+{
+	class compatibleItems: compatibleItems
+	{
+		rhsusf_acc_grip1 = 1;
+		rhsusf_acc_grip2 = 1;
+		rhsusf_acc_grip2_tan = 1;
+		rhsusf_acc_grip2_wd = 1;
+		rhsusf_acc_grip3 = 1;
+		rhsusf_acc_grip3_tan = 1;
+		rhs_acc_grip_rk2 = 1;
+		rhs_acc_grip_rk6 = 1;
+		rhs_acc_grip_ffg2 = 1;
+		rhsusf_acc_rvg_blk = 1;
+		rhsusf_acc_rvg_de = 1;
+		rhsusf_acc_tacsac_blk = 1;
+		rhsusf_acc_tacsac_tan = 1;
+		rhsusf_acc_tacsac_blue = 1;
+		rhsusf_acc_tdstubby_blk = 1;
+		rhsusf_acc_tdstubby_tan = 1;
+		rhsusf_acc_kac_grip = 1;
+	};
+};
+class CfgMagazineWells
+{
+	class CBA_545x39_AK
+	{
+		RHS_Magazines[] = {"rhs_30Rnd_545x39_AK","rhs_30Rnd_545x39_7N6_AK","rhs_30Rnd_545x39_AK_no_tracers","rhs_30Rnd_545x39_7N6_green_AK","rhs_30Rnd_545x39_AK_green","rhs_30Rnd_545x39_AK_plum_green","rhs_30Rnd_545x39_7U1_AK","rhs_30Rnd_545x39_7N6M_AK","rhs_30Rnd_545x39_7N6M_green_AK","rhs_30Rnd_545x39_7N6M_plum_AK","rhs_30Rnd_545x39_7N10_AK","rhs_30Rnd_545x39_7N10_plum_AK","rhs_30Rnd_545x39_7N10_camo_AK","rhs_30Rnd_545x39_7N10_desert_AK","rhs_30Rnd_545x39_7N22_AK","rhs_30Rnd_545x39_7N22_plum_AK","rhs_30Rnd_545x39_7N22_camo_AK","rhs_30Rnd_545x39_7N22_desert_AK","rhs_30Rnd_545x39_7N10_2mag_AK","rhs_30Rnd_545x39_7N10_2mag_plum_AK","rhs_30Rnd_545x39_7N10_2mag_camo_AK","rhs_30Rnd_545x39_7N10_2mag_desert_AK","rhs_45Rnd_545x39_AK","rhs_45Rnd_545x39_7N6_AK","rhs_45Rnd_545x39_7N10_AK","rhs_45Rnd_545x39_7N22_AK","rhs_45Rnd_545x39_AK_green","rhs_45Rnd_545x39_7U1_AK"};
+	};
+	class CBA_545x39_RPK
+	{
+		RHS_Magazines[] = {"rhs_45Rnd_545x39_AK","rhs_45Rnd_545x39_7N6_AK","rhs_45Rnd_545x39_7N10_AK","rhs_45Rnd_545x39_7N22_AK","rhs_45Rnd_545x39_AK_green","rhs_45Rnd_545x39_7U1_AK"};
+	};
+	class CBA_762x39_AK{};
+	class CBA_762x39_RPK{};
 };

--- a/hlc_WP_FAL/config.cpp
+++ b/hlc_WP_FAL/config.cpp
@@ -267,7 +267,7 @@ class CfgWeapons {
                 iconPosition[] = { 0.2, 0.45 };
                 iconScale = 0.25;
             };
-            class MuzzleSlot : asdg_MuzzleSlot_762 {                
+            class MuzzleSlot : asdg_MuzzleSlot_762 {
                 iconPosition[] = { 0.0, 0.45 };
                 iconScale = 0.2;
                 };
@@ -330,21 +330,21 @@ class CfgWeapons {
             __AI_ROF_RIFLE_MEDIUM_HSCOPE_SINGLE;
         };
         class fullauto_medium : FullAuto {
-            
-                showToPlayer = 0; 
-                aiBurstTerminable = 1; 
-                burst = 4; 
-                __AI_ROF_RIFLE_MEDIUM_CLOSE_BURST; 
-        }; 
+
+                showToPlayer = 0;
+                aiBurstTerminable = 1;
+                burst = 4;
+                __AI_ROF_RIFLE_MEDIUM_CLOSE_BURST;
+        };
     };
 
     class hlc_rifle_falosw : hlc_fal_base {
         author = "Pete, Enron, Toadie";
-        AB_barrelTwist=12;
-        AB_barrelLength=13;
-        ACE_barrelTwist = 304.8;
-        ACE_barrelLength = 330.2;
-        initspeed = -0.868;
+        AB_barrelTwist=10;
+        AB_barrelLength=11;
+        ACE_barrelTwist = 254;
+        ACE_barrelLength = 279.4;
+        initspeed = -0.735;
         scope = public;
         displayName = $STR_NIA_rifle_falosw;
         handAnim[] = {"OFP2_ManSkeleton", "\hlc_wp_fal\gesture\newgesture\gesture_OSW_STD.rtm"};
@@ -352,7 +352,7 @@ class CfgWeapons {
         reloadAction = "HLC_GestureReloadOSW";
         model = "\hlc_wp_FAL\mesh\sa58\osw.p3d";
         picture = "\hlc_wp_FAL\tex\ui\gear_osw_x_ca";
-        
+
         hiddenSelections[] = { "Reciever", "Barrel", "Frontsight", "Foregrip", "Grip", "Rearsight", "Stock", "Magazine", "Rails", "VFG" };
         hiddenSelectionsTextures[] = { "hlc_wp_fal\tex\israeli\rec_sanitary_co.tga", "hlc_wp_fal\tex\sa58\barrel-match_co.tga", "hlc_wp_fal\tex\fsight_co.tga", "hlc_wp_fal\tex\sa58\foregrip-dsa_co.tga", "hlc_wp_fal\tex\grip-enfield_co.tga", "hlc_wp_fal\tex\israeli\rearsight-slr_co.tga", "hlc_wp_fal\tex\sa58\foldingstock_co.tga", "hlc_wp_fal\tex\mag-20_co.tga", "hlc_wp_fal\tex\dsatoprails_co.tga", "hlc_wp_fal\tex\sa58\verticalgrip_co.tga" };
         discretedistance[] = {/*100,*/200,300,400,500,600,700/*,800,900*/};
@@ -499,7 +499,7 @@ class CfgWeapons {
     class UGL_F;
     class hlc_rifle_osw_GL : hlc_rifle_falosw {
         class WeaponSlotsInfo  {
-            mass = 130; 
+            mass = 131;
             class MuzzleSlot : asdg_MuzzleSlot_762 {
                 iconPosition[] = { 0.0, 0.45 };
                 iconScale = 0.2;
@@ -577,7 +577,7 @@ class CfgWeapons {
         AB_barrelTwist=12;
         AB_barrelLength=21.7;
         ACE_barrelTwist = 304.8;
-        ACE_barrelLength = 551.18;
+        ACE_barrelLength = 554.4;
         scope = public;
         displayName = $STR_NIA_rifle_SLR;
         descriptionShort = $STR_NIA_FAL_DESC;
@@ -590,7 +590,7 @@ class CfgWeapons {
         picture = "\hlc_wp_FAL\tex\ui\gear_slr_x_ca";
         hiddenSelections[] = { "Reciever", "Barrel", "Frontsight", "GasBlock", "Foregrip", "Grip", "Rearsight", "Stock", "Magazine" };
         hiddenSelectionsTextures[] = { "hlc_wp_fal\tex\israeli\rec_sanitary_co.tga", "hlc_wp_fal\tex\lithgow\barrel-slr_co.tga", "hlc_wp_fal\tex\israeli\frontsight-1_co.tga", "hlc_wp_fal\tex\lithgow\fsight2_co.tga", "hlc_wp_fal\tex\lithgow\fore-slr_co.tga", "hlc_wp_fal\tex\c1\grip-enfield_co.tga", "hlc_wp_fal\tex\israeli\rearsight-slr_co.tga", "hlc_wp_fal\tex\lithgow\stock-solid_co.tga", "hlc_wp_fal\tex\israeli\mag-20_co.tga" };
-        inertia = 0.43;  
+        inertia = 0.43;
         __DEXTERITY(4.5, 0);
         discretedistance[] = {/*100,*/200,300,400,500,600,700/*,800*/};
         discretedistanceinitindex = 0;
@@ -706,6 +706,10 @@ class CfgWeapons {
 
     class hlc_rifle_FAL5061Rail : hlc_fal_base {
         scope = public;
+        AB_barrelTwist=12;
+        AB_barrelLength=17.2;
+        ACE_barrelTwist = 304.8;
+        ACE_barrelLength = 436.9;
         author = "Bohemia Interactive, Arby25, Toadie";
         displayName = $STR_NIA_rifle_5061ris;
         model = "\hlc_wp_FAL\mesh\FN_FAL\fnFal_rails.p3d";
@@ -719,7 +723,7 @@ class CfgWeapons {
         discretedistance[] = {  200, 300, 400, 500, 600, 700 };
         discretedistanceinitindex = 2;
         class WeaponSlotsInfo : WeaponSlotsInfo {
-            mass = 96;
+            mass = 92;
             class CowsSlot : asdg_OpticRail1913 {
                 iconPosition[] = { 0.5, 0.35 };
                 iconScale = 0.2;
@@ -750,9 +754,9 @@ class CfgWeapons {
         scope = public;
         author = "Bohemia Interactive, Arby25, Toadie";
         AB_barrelTwist=12;
-        AB_barrelLength=18;
+        AB_barrelLength=17.2;
         ACE_barrelTwist = 304.8;
-        ACE_barrelLength = 457.2;
+        ACE_barrelLength = 436.9;
         displayName = $STR_NIA_rifle_5061;
         descriptionShort = $STR_NIA_FAL_DESC;
         reloadAction = "HLC_GestureReloadFALLONG";
@@ -767,7 +771,7 @@ class CfgWeapons {
         inertia = 0.39;
         __DEXTERITY(3.9, 0);
         class WeaponSlotsInfo : WeaponSlotsInfo {
-            mass = 85;
+            mass = 81;
             class CowsSlot: asdg_OpticRail {
                 iconPosition[] = { 0.5, 0.35 };
                 iconScale = 0.2;
@@ -801,9 +805,9 @@ class CfgWeapons {
         scope = public;
         author = "Bohemia Interactive, Arby25, Toadie, Clifton Vlodhammer";
         AB_barrelTwist = 12;
-        AB_barrelLength = 18;
+        AB_barrelLength = 21;
         ACE_barrelTwist = 304.8;
-        ACE_barrelLength = 457.2;
+        ACE_barrelLength = 533;
         displayName = $STR_NIA_rifle_5000;
         descriptionShort = "Battle Rifle<br/>Caliber: 7.62x51mm NATO";
         reloadAction = "HLC_GestureReloadFALLONG";
@@ -818,7 +822,7 @@ class CfgWeapons {
         inertia = 0.43;
         __DEXTERITY(4.3, 0);
         class WeaponSlotsInfo : WeaponSlotsInfo {
-            mass = 90;
+            mass = 94;
         };
         class __MAGSWITCHCLASS {
             hlc_50Rnd_762x51_B_fal = "hlc_rifle_FAL5000_XMAG";
@@ -840,6 +844,10 @@ class CfgWeapons {
 
     class hlc_rifle_FAL5000Rail : hlc_rifle_FAL5061Rail {
         scope = public;
+        AB_barrelTwist = 12;
+        AB_barrelLength = 21;
+        ACE_barrelTwist = 304.8;
+        ACE_barrelLength = 533;
         displayName = $STR_NIA_rifle_5000ris;
         author = "Bohemia Interactive, Arby25, Toadie, Clifton Vlodhammer";
         model = "\hlc_wp_FAL\mesh\FN_FAL\fnFal_full_rails.p3d";
@@ -847,7 +855,7 @@ class CfgWeapons {
         hiddenSelections[] = { "Main", "Stock", "Barrel", "Rail", "Magazine" };
         hiddenSelectionsTextures[] = { "hlc_wp_fal\tex\bis_falpara\fnfal_co.tga", "hlc_wp_fal\tex\arby25_fal\fnfal2_co.tga", "hlc_wp_fal\tex\lithgow\barrel-slr_co.tga", "hlc_wp_fal\tex\bis_pvs4\anpvs4_co.tga", "hlc_core\tex\magazines\FALmag_20rnd_co.tga" };
         class WeaponSlotsInfo : WeaponSlotsInfo {
-            mass = 99;
+            mass = 103;
         };
 		inertia = 0.5;
         __DEXTERITY(4.6, 0);
@@ -899,7 +907,7 @@ class CfgWeapons {
         AB_barrelTwist=12;
         AB_barrelLength=21.7;
         ACE_barrelTwist = 304.8;
-        ACE_barrelLength = 551.18;
+        ACE_barrelLength = 554.4;
         scope = public;
         displayName = $STR_NIA_rifle_L1A1;
         descriptionShort = $STR_NIA_FAL_DESC;
@@ -931,7 +939,7 @@ class CfgWeapons {
         AB_barrelTwist=12;
         AB_barrelLength=21.7;
         ACE_barrelTwist = 304.8;
-        ACE_barrelLength = 551.18;
+        ACE_barrelLength = 554.4;
         scope = public;
         displayName = $STR_NIA_rifle_C1A1;
         hiddenSelections[] = { "Reciever", "Barrel", "Frontsight", "GasBlock", "Foregrip", "Grip", "Rearsight", "Stock", "Magazine" };
@@ -988,7 +996,7 @@ class CfgWeapons {
                 soundSetShot[] = { "FAL_Shot_SoundSet", "FAL2_tail_SoundSet" };
             };
             __MOA(2.4);
-        };       
+        };
         class single_medium_optics1 : Single {
             showToPlayer = 0;
             requiredoptictype = 1;

--- a/hlc_WP_FAL/stringtable.xml
+++ b/hlc_WP_FAL/stringtable.xml
@@ -78,34 +78,34 @@
         <Chinesesimp>Steyr Stgw.58</Chinesesimp>
       </Key>
       <Key ID="STR_NIA_rifle_5061ris">
-        <Original>FN FAL 50.61 (RIS)</Original>
-        <English>FN FAL 50.61 (RIS)</English>
-        <Czech>FN FAL 50.61 (RIS)</Czech>
-        <French>FN FAL 50.61 (RIS)</French>
-        <Spanish>FN FAL 50.61 (RIS)</Spanish>
-        <Italian>FN FAL 50.61 (RIS)</Italian>
-        <Polish>FN FAL 50.61 (RIS)</Polish>
-        <Portuguese>FN FAL 50.61 (RIS)</Portuguese>
-        <Russian>FN FAL 50.61 (RIS)</Russian>
-        <German>FN FAL 50.61 (RIS)</German>
-        <Japanese>FN FAL 50.61 (RIS)</Japanese>
-        <Korean>FN FAL 50.61 (RIS)</Korean>
-        <Chinesesimp>FN FAL 50.61 (RIS)</Chinesesimp>
+        <Original>FN FAL 50.63 (RIS)</Original>
+        <English>FN FAL 50.63 (RIS)</English>
+        <Czech>FN FAL 50.63 (RIS)</Czech>
+        <French>FN FAL 50.63 (RIS)</French>
+        <Spanish>FN FAL 50.63 (RIS)</Spanish>
+        <Italian>FN FAL 50.63 (RIS)</Italian>
+        <Polish>FN FAL 50.63 (RIS)</Polish>
+        <Portuguese>FN FAL 50.63 (RIS)</Portuguese>
+        <Russian>FN FAL 50.63 (RIS)</Russian>
+        <German>FN FAL 50.63 (RIS)</German>
+        <Japanese>FN FAL 50.63 (RIS)</Japanese>
+        <Korean>FN FAL 50.63 (RIS)</Korean>
+        <Chinesesimp>FN FAL 50.63 (RIS)</Chinesesimp>
       </Key>
       <Key ID="STR_NIA_rifle_5061">
-        <Original>FN FAL 50.61</Original>
-        <English>FN FAL 50.61</English>
-        <Czech>FN FAL 50.61</Czech>
-        <French>FN FAL 50.61</French>
-        <Spanish>FN FAL 50.61</Spanish>
-        <Italian>FN FAL 50.61</Italian>
-        <Polish>FN FAL 50.61</Polish>
-        <Portuguese>FN FAL 50.61</Portuguese>
-        <Russian>FN FAL 50.61</Russian>
-        <German>FN FAL 50.61</German>
-        <Japanese>FN FAL 50.61</Japanese>
-        <Korean>FN FAL 50.61</Korean>
-        <Chinesesimp>FN FAL 50.61</Chinesesimp>
+        <Original>FN FAL 50.63</Original>
+        <English>FN FAL 50.63</English>
+        <Czech>FN FAL 50.63</Czech>
+        <French>FN FAL 50.63</French>
+        <Spanish>FN FAL 50.63</Spanish>
+        <Italian>FN FAL 50.63</Italian>
+        <Polish>FN FAL 50.63</Polish>
+        <Portuguese>FN FAL 50.63</Portuguese>
+        <Russian>FN FAL 50.63</Russian>
+        <German>FN FAL 50.63</German>
+        <Japanese>FN FAL 50.63</Japanese>
+        <Korean>FN FAL 50.63</Korean>
+        <Chinesesimp>FN FAL 50.63</Chinesesimp>
       </Key>
       <Key ID="STR_NIA_rifle_5000">
         <Original>FN FAL 50.00</Original>

--- a/hlc_core/Cfgammo.hpp
+++ b/hlc_core/Cfgammo.hpp
@@ -251,7 +251,7 @@ class CfgAmmo {
         model = "\hlc_core\mesh\bullettracer\tracer_dim";
         tracerscale = 1;
         tracerstarttime = 0.05;
-        typicalSpeed = 601;
+        typicalSpeed = 670.6;
         visibleFire = 3.8;
         supersonicCrackNear[] = {};
         supersonicCrackFar[] = {};

--- a/hlc_core/Cfgammo.hpp
+++ b/hlc_core/Cfgammo.hpp
@@ -1,5 +1,5 @@
 ﻿//Ballistics data presented largely by Spartan0536
-//Other suppliers commented as approriate. 
+//Other suppliers commented as approriate.
 class CfgAmmo {
     class B_762x51_Ball;
     class B_556x45_Ball;
@@ -251,30 +251,29 @@ class CfgAmmo {
         model = "\hlc_core\mesh\bullettracer\tracer_dim";
         tracerscale = 1;
         tracerstarttime = 0.05;
-        typicalSpeed = 312;
-        visibleFire = 0.55;
-        audibleFire = 0.65;
+        typicalSpeed = 601;
+        visibleFire = 3.8;
         supersonicCrackNear[] = {};
         supersonicCrackFar[] = {};
         ACE_caliber = 7.823;
-        ACE_bulletLength = 37.821;
-        ACE_bulletMass = 14.256;
+        ACE_bulletLength = 31.623;
+        ACE_bulletMass = 7.77587;
         ACE_ammoTempMuzzleVelocityShifts[] = { -26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19 };
-        ACE_ballisticCoefficients[] = { 0.608 };
+        ACE_ballisticCoefficients[] = { 0.358 };
         ACE_velocityBoundaries[] = {};
         ACE_standardAtmosphere = "ICAO";
         ACE_dragModel = 1;
-        ACE_muzzleVelocities[] = { 300, 320, 340 };
+        ACE_muzzleVelocities[] = { 578, 616, 655 };
         ACE_barrelLengths[] = { 228.6, 406.4, 508.0 };
         AB_caliber = 0.308;
-        AB_bulletLength = 1.489;
-        AB_bulletMass = 220;
+        AB_bulletLength = 1.245;
+        AB_bulletMass = 120;
         AB_ammoTempMuzzleVelocityShifts[] = { -26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19 };
-        AB_ballisticCoefficients[] = { 0.608 };
+        AB_ballisticCoefficients[] = { 0.358 };
         AB_velocityBoundaries[] = {};
         AB_standardAtmosphere = "ICAO";
         AB_dragModel = 1;
-        AB_muzzleVelocities[] = { 300, 320, 340 };
+        AB_muzzleVelocities[] = { 578, 616, 655 };
         AB_barrelLengths[] = { 9, 16, 20 };
     };
     /*
@@ -467,9 +466,9 @@ class CfgAmmo {
         airFriction = -0.00100899;
         typicalSpeed = 908.4;
         hit = 13.92;
-        tracerScale = 1.2; 
-        tracerStartTime = 0.073;  
-        tracerEndTime = 2.15957;  
+        tracerScale = 1.2;
+        tracerStartTime = 0.073;
+        tracerEndTime = 2.15957;
         caliber = 1.123;
         deflecting = 22;
         ACE_caliber = 7.823;
@@ -511,7 +510,7 @@ class CfgAmmo {
         ACE_barrelLengths[] = { 406.4, 508.0, 609.6, 660.4 };
     };
     //Ballistics by Ruthberg, CO ACE3
-    // NO LONGER BEING MAINTAINED, Retaining for Legacy. 
+    // NO LONGER BEING MAINTAINED, Retaining for Legacy.
     class HLC_762x51_Barrier : HLC_762x51_ball {
         airFriction = -0.00102338;
         caliber = 1.5;
@@ -1117,7 +1116,7 @@ class CfgAmmo {
         ACE_muzzleVelocities[] = { 783, 710 };
         ACE_barrelLengths[] = { 583, 254 };
     };
-    // 
+    //
     // Provided by Spartan0536
     class HLC_GP11_tracer : HLC_GP11_FMJ
     {
@@ -1490,8 +1489,8 @@ class CfgAmmo {
         AB_muzzleVelocities[] = { 300, 320, 340 };
         ACE_muzzleVelocities[] = { 300, 320, 340 };
     };
-    
-    
+
+
     //.357 SIG
 
     /*
@@ -1641,7 +1640,7 @@ class CfgAmmo {
         AB_muzzleVelocities[] = { 350, 380, 420 };
         ACE_muzzleVelocities[] = { 350, 380, 420 };
     };
-    
+
     //10mm AUTO
     //SMG optimised
     /*

--- a/hlc_wp_AR15/stringtable.xml
+++ b/hlc_wp_AR15/stringtable.xml
@@ -275,19 +275,19 @@
                 <Chinesesimp>.300AAC TAC-TX 30Rnd STANAG Magazine</Chinesesimp>
             </Key>
             <Key ID="STR_NIA_50Rnd_300BLK_M_STANAG">
-                <Original>.300AAC TAC-TX 50Rnd STANAG Magazine</Original>
-                <English>.300AAC TAC-TX 50Rnd STANAG Magazine</English>
-                <Czech>.300AAC TAC-TX 50Rnd STANAG Magazine</Czech>
-                <French>Chargeur STANAG 50 Coups Cal .300AAC TAC-TX</French>
-                <Spanish>.300AAC TAC-TX 50Rnd STANAG Magazine</Spanish>
-                <Italian>.300AAC TAC-TX 50Rnd STANAG Magazine</Italian>
-                <Polish>.300AAC TAC-TX 50Rnd STANAG Magazine</Polish>
-                <Portuguese>.300AAC TAC-TX 50Rnd STANAG Magazine</Portuguese>
-                <Russian>.300AAC TAC-TX 50Rnd STANAG Magazine</Russian>
-                <German>.300AAC TAC-TX 50Rnd STANAG Magazine</German>
-                <Japanese>.300AAC TAC-TX 50発入り STANAG マガジン</Japanese>
-                <Korean>.300AAC TAC-TX 50Rnd STANAG Magazine</Korean>
-                <Chinesesimp>.300AAC TAC-TX 50Rnd STANAG Magazine</Chinesesimp>
+                <Original>.300AAC EPR 50Rnd STANAG Magazine</Original>
+                <English>.300AAC EPR 50Rnd STANAG Magazine</English>
+                <Czech>.300AAC EPR 50Rnd STANAG Magazine</Czech>
+                <French>Chargeur STANAG 50 Coups Cal .300AAC EPR</French>
+                <Spanish>.300AAC EPR 50Rnd STANAG Magazine</Spanish>
+                <Italian>.300AAC EPR 50Rnd STANAG Magazine</Italian>
+                <Polish>.300AAC EPR 50Rnd STANAG Magazine</Polish>
+                <Portuguese>.300AAC EPR 50Rnd STANAG Magazine</Portuguese>
+                <Russian>.300AAC EPR 50Rnd STANAG Magazine</Russian>
+                <German>.300AAC EPR 50Rnd STANAG Magazine</German>
+                <Japanese>.300AAC EPR 50発入り STANAG マガジン</Japanese>
+                <Korean>.300AAC EPR 50Rnd STANAG Magazine</Korean>
+                <Chinesesimp>.300AAC EPR 50Rnd STANAG Magazine</Chinesesimp>
             </Key>
         </Container>
         <Container name="Acc_names">

--- a/hlc_wp_ak/config.cpp
+++ b/hlc_wp_ak/config.cpp
@@ -887,8 +887,8 @@ class CfgWeapons {
     class hlc_ak_base : Rifle_Base_F {
         magazineReloadSwitchPhase = 0.5;
         author = "Toadie";
-        recoil = "recoil_mk20";
-    
+        recoil = "recoil_aks";
+
         deployedPivot = "deploypivot";       /// what point should be used to be on surface while unfolded
         hasBipod = false;          /// a weapon with bipod obviously has a bipod
         //    soundBipodDown[] = { "\hlc_wp_ak\snd\rpk_bipodout", db - 3, 1, 20 }; /// sound of unfolding the bipod
@@ -998,43 +998,43 @@ class CfgWeapons {
             class SilencedSound : BaseSoundModeType { /// Sounds inside this class are used when soundTypeIndex = 1, according to sounds[]
                 soundSetShot[] = { "Nia_ak74_silencerShot_SoundSet", "Nia_ak74_silencerTail_SoundSet" };
             };
-        }; 
+        };
         class AI_Burst_close : FullAuto {
-            
-                showToPlayer = 0; 
-                aiBurstTerminable = 1; 
-                burst = 7; 
-                __AI_ROF_AK_CLOSE_BURST; 
-        }; 
-        class AI_Burst_far : AI_Burst_close {
-            
-                burst = 4; 
-                __AI_ROF_AK_FAR_BURST; 
-        }; 
-        class AI_Single_optics1 : Single {
-            
-                showToPlayer = 0; 
-                requiredOpticType = 1; 
-                __AI_ROF_AK_MSCOPE_SINGLE; 
-        }; 
-        class AI_Single_optics2 : AI_Single_optics1 {
-            
-                requiredOpticType = 2; 
-                __AI_ROF_AK_HSCOPE_SINGLE; 
-        }; 
-        class Burst3 : Single {
-            
-                __AI_ROF_AK_SHORT_BURST; 
-                burst = 3; 
-                displayName = $STR_DN_MODE_BURST; 
-                textureType = "burst"; 
-                soundBurst = 0; 
+
                 showToPlayer = 0;
-        }; 
+                aiBurstTerminable = 1;
+                burst = 7;
+                __AI_ROF_AK_CLOSE_BURST;
+        };
+        class AI_Burst_far : AI_Burst_close {
+
+                burst = 4;
+                __AI_ROF_AK_FAR_BURST;
+        };
+        class AI_Single_optics1 : Single {
+
+                showToPlayer = 0;
+                requiredOpticType = 1;
+                __AI_ROF_AK_MSCOPE_SINGLE;
+        };
+        class AI_Single_optics2 : AI_Single_optics1 {
+
+                requiredOpticType = 2;
+                __AI_ROF_AK_HSCOPE_SINGLE;
+        };
+        class Burst3 : Single {
+
+                __AI_ROF_AK_SHORT_BURST;
+                burst = 3;
+                displayName = $STR_DN_MODE_BURST;
+                textureType = "burst";
+                soundBurst = 0;
+                showToPlayer = 0;
+        };
         class Burst2 : Burst3 {
-            
-                burst = 2; 
-                textureType = "dual"; 
+
+                burst = 2;
+                textureType = "dual";
         };
         drysound[] = {"\hlc_wp_ak\snd\empty_assaultrifles", 1, 1, 10};
         reloadMagazineSound[] = { "\hlc_wp_ak\snd\soundshaders\ak74\ak74m_reload", 0.8, 1, 20 };
@@ -1089,7 +1089,7 @@ class CfgWeapons {
         picture = "\hlc_wp_ak\tex\ui\gear_ak74_ca";
         hiddenSelections[] = { "Main", "Dovetail", "Mount" };
         hiddenSelectionsTextures[] = { "hlc_wp_ak\tex\rifleman_ak74\body_co.tga", "hlc_wp_ak\tex\rifleman_ak74\mount_co.tga", "hlc_wp_ak\tex\rrxviii_mtk83\mtk-83_co.tga" };
-        bg_bipod = 0; 
+        bg_bipod = 0;
         discreteDistance[] = { 200, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000 };
         discreteDistanceCameraPoint[] = { "eye", "eye_100", "eye_200", "eye_300", "eye_400", "eye_500", "eye_600", "eye_700", "eye_800", "eye_900", "eye_1000"/*, "eye", "eye", "eye", "eye", "eye", "eye", "eye", "eye", "eye", "eye", "eye", "eye", "eye" */ };
         cameraDir = "eye_look";
@@ -1208,7 +1208,7 @@ class CfgWeapons {
         displayName = "Izhmash AKS74";
         hiddenSelections[] = { "Main", "Dovetail", "Mount" };
         hiddenSelectionsTextures[] = { "hlc_wp_ak\tex\rifleman_aks\aks_co.tga", "hlc_wp_ak\tex\rifleman_ak74\mount_co.tga", "hlc_wp_ak\tex\rrxviii_mtk83\mtk-83_co.tga" };
-        bg_bipod = 0; 
+        bg_bipod = 0;
         class WeaponSlotsInfo : WeaponSlotsInfo {
             mass = 58;
         };
@@ -1229,7 +1229,7 @@ class CfgWeapons {
         model = "\hlc_wp_ak\mesh\aks74\aks74_45rnd.p3d";
         inertia = 0.29+0.08;
 		__DEXTERITY(2.9+0.8,0);
-        
+
     };
     class hlc_rifle_aks74_60rnd : hlc_rifle_aks74
     {
@@ -1246,6 +1246,8 @@ class CfgWeapons {
         deployedPivot = "deploypivot";       /// what point should be used to be on surface while unfolded
         author = "Maibatsu, Toadie";
         scope = public;
+        ACE_barrelLength = 414.02;
+        ACE_barrelTwist = 199.898;
         displayName = "Izhmash AK12";
         model = "\hlc_wp_ak\mesh\ak12\ak12.p3d";
         picture = "\hlc_wp_ak\tex\ui\gear_ak12_ca";
@@ -1361,34 +1363,34 @@ class CfgWeapons {
 
         };
         class AI_Burst_close : FullAuto {
-            
-                showToPlayer = 0; 
-                aiBurstTerminable = 1; 
-                burst = 4; 
-                __AI_ROF_RIFLE_SMALL_CLOSE_BURST; 
-        }; 
+
+                showToPlayer = 0;
+                aiBurstTerminable = 1;
+                burst = 4;
+                __AI_ROF_RIFLE_SMALL_CLOSE_BURST;
+        };
         class AI_Single_optics1 : Single {
-            
-                showToPlayer = 0; 
-                requiredOpticType = 1; 
-                __AI_ROF_RIFLE_SMALL_MSCOPE_SINGLE; 
-        }; 
+
+                showToPlayer = 0;
+                requiredOpticType = 1;
+                __AI_ROF_RIFLE_SMALL_MSCOPE_SINGLE;
+        };
         class AI_Single_optics2 : AI_Single_optics1 {
-            
-                requiredOpticType = 2; 
-                __AI_ROF_RIFLE_SMALL_HSCOPE_SINGLE; 
-        }; 
+
+                requiredOpticType = 2;
+                __AI_ROF_RIFLE_SMALL_HSCOPE_SINGLE;
+        };
         class SemiAuto : Single {
             showToPlayer = 0;
-                __AI_ROF_RIFLE_SMALL_SEMI; 
-        }; 
+                __AI_ROF_RIFLE_SMALL_SEMI;
+        };
         class AI_far : Single {
-            
-                showToPlayer = 0; 
-                aiBurstTerminable = 1; 
-                burst = 5; 
-                reloadtime = 0.2; 
-                __AI_ROF_RIFLE_SMALL_FAR_FAST_SINGLE; 
+
+                showToPlayer = 0;
+                aiBurstTerminable = 1;
+                burst = 5;
+                reloadtime = 0.2;
+                __AI_ROF_RIFLE_SMALL_FAR_FAST_SINGLE;
         };
         class Library {
             libTextDesc = "Izhmash AK12 5.45mm";
@@ -1502,7 +1504,7 @@ class CfgWeapons {
         hiddenSelectionsTextures[] = { "hlc_wp_ak\tex\ak12\ak12_m_co.tga", "hlc_wp_ak\tex\ak12\ak12_upper_co.tga", "hlc_wp_ak\tex\toadie_offset\rail_co.tga", "hlc_wp_ak\tex\mil_aks\aks-74u_co.tga", "hlc_wp_ak\tex\gp30\gp30_co.tga"};
         discretedistance[] = { 200, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000 };
         discretedistanceinitindex = 2;
-        bg_bipod = 0; 
+        bg_bipod = 0;
         reloadMagazineSound[] = { "\hlc_wp_ak\snd\soundshaders\ak12\ak12_reload2", 1, 1, 20 };
         handAnim[] = { "OFP2_ManSkeleton", "hlc_wp_ak\anim\new_aks74uhandgesture.rtm" };
         reloadAction = "HLC_GestureReloadAK12New";
@@ -1604,10 +1606,12 @@ class CfgWeapons {
     class hlc_rifle_RPK12 : hlc_rifle_ak12 {
         dlc = "Niarms_AK";
         AB_barrelLength=23.2;
+        AB_barrelTwist = 9.45;
         ACE_barrelLength = 589.28;
+        ACE_barrelTwist = 240.03;
         agm_bipod=1;
         cse_bipod = 1;
-        bg_bipod = 1; 
+        bg_bipod = 1;
         hasBipod = true;          /// a weapon with bipod obviously has a bipod
         soundBipodDown[] = { "\hlc_wp_ak\snd\rpk_bipodin", db - 3, 1, 20 }; /// sound of unfolding the bipod
         soundBipodUp[] = { "\hlc_wp_ak\snd\rpk_bipodout", db - 3, 1, 20 }; /// sound of folding the bipod
@@ -1734,7 +1738,7 @@ class CfgWeapons {
         hiddenSelectionsTextures[] = { "hlc_wp_ak\tex\mil_aks\aks-74u_co.tga", "hlc_wp_ak\tex\rifleman_ak74\mount_co.tga", "hlc_wp_ak\tex\rrxviii_mtk83\mtk-83_co.tga","hlc_wp_ak\tex\rifleman_ak74\body_co.tga" };
         discretedistance[] = {350,500};
         discretedistanceinitindex = 0;
-        bg_bipod = 0; 
+        bg_bipod = 0;
         handAnim[] = { "OFP2_ManSkeleton", "hlc_wp_ak\anim\new_aks74uhandgesture.rtm" };
         reloadAction = "HLC_GestureReloadAK545OneHand";
         class FullAuto: FullAuto {
@@ -1817,11 +1821,11 @@ class CfgWeapons {
         picture = "\hlc_wp_ak\tex\ui\gear_ak47_ca";
         hiddenSelections[] = { "Main","upper", "Dovetail", "Mount", "Magazine" };
         hiddenSelectionsTextures[] = { "hlc_wp_ak\tex\47_rec_co.tga","hlc_wp_ak\tex\upper_co.tga", "hlc_wp_ak\tex\rifleman_ak74\mount_co.tga", "hlc_wp_ak\tex\rifleman_ak74\mount_co.tga", "hlc_wp_ak\tex\magazine_co.tga" };
-        recoil = "recoil_mx";
+        recoil = "recoil_akm";
         discreteDistance[] = { 200, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000 };
         discreteDistanceCameraPoint[] = { "eye", "eye_100", "eye_200", "eye_300", "eye_400", "eye_500", "eye_600", "eye_700", "eye_800", "eye_900", "eye_1000"/*, "eye", "eye", "eye", "eye", "eye", "eye", "eye", "eye", "eye", "eye", "eye", "eye", "eye" */ };
         cameraDir = "eye_look";
-        bg_bipod = 0; 
+        bg_bipod = 0;
         descriptionShort = "Assault rifle<br/>Caliber: 7.62mm";
         reloadAction = "HLC_GestureReloadAK762";
         reloadMagazineSound[] = {"\hlc_wp_ak\snd\soundshaders\ak47\ak_reload_longer",0.9,1,30};
@@ -1848,41 +1852,41 @@ class CfgWeapons {
             };
         };
         class AI_Burst_close : FullAuto {
-            
-                showToPlayer = 0; 
-                aiBurstTerminable = 1; 
-                burst = 7; 
-                __AI_ROF_AK_CLOSE_BURST; 
-        }; 
-        class AI_Burst_far : AI_Burst_close {
-            
-                burst = 4; 
-                __AI_ROF_AK_FAR_BURST; 
-        }; 
-        class AI_Single_optics1 : Single {
-            
-                showToPlayer = 0; 
-                requiredOpticType = 1; 
-                __AI_ROF_AK_MSCOPE_SINGLE; 
-        }; 
-        class AI_Single_optics2 : AI_Single_optics1 {
-            
-                requiredOpticType = 2; 
-                __AI_ROF_AK_HSCOPE_SINGLE; 
-        }; 
-        class Burst3 : Single {
-            
-                __AI_ROF_AK_SHORT_BURST; 
-                burst = 3; 
-                displayName = $STR_DN_MODE_BURST; 
-                textureType = "burst"; 
-                soundBurst = 0; 
+
                 showToPlayer = 0;
-        }; 
+                aiBurstTerminable = 1;
+                burst = 7;
+                __AI_ROF_AK_CLOSE_BURST;
+        };
+        class AI_Burst_far : AI_Burst_close {
+
+                burst = 4;
+                __AI_ROF_AK_FAR_BURST;
+        };
+        class AI_Single_optics1 : Single {
+
+                showToPlayer = 0;
+                requiredOpticType = 1;
+                __AI_ROF_AK_MSCOPE_SINGLE;
+        };
+        class AI_Single_optics2 : AI_Single_optics1 {
+
+                requiredOpticType = 2;
+                __AI_ROF_AK_HSCOPE_SINGLE;
+        };
+        class Burst3 : Single {
+
+                __AI_ROF_AK_SHORT_BURST;
+                burst = 3;
+                displayName = $STR_DN_MODE_BURST;
+                textureType = "burst";
+                soundBurst = 0;
+                showToPlayer = 0;
+        };
         class Burst2 : Burst3 {
-            
-                burst = 2; 
-                textureType = "dual"; 
+
+                burst = 2;
+                textureType = "dual";
         };
 
         class Library {
@@ -1960,7 +1964,7 @@ class CfgWeapons {
             hlc_75Rnd_762x39_AP_rpk = "hlc_rifle_akm_75rnd";
             default = "hlc_rifle_akm";
         };
-    }; 
+    };
     class hlc_rifle_akm_45rnd : hlc_rifle_akm
     {
         scopeArsenal = 0;
@@ -2043,10 +2047,10 @@ class CfgWeapons {
         AB_barrelTwist=9.45;
         AB_barrelLength=23.2;
         ACE_barrelTwist = 240.03;
-        ACE_barrelLength = 589.28; 
+        ACE_barrelLength = 589.28;
         agm_bipod=1;
         cse_bipod = 1;
-        bg_bipod = 1; 
+        bg_bipod = 1;
         magazines[] = { __762x39_MAGS, __762x39_BI_MAGS };
         model = "\hlc_wp_ak\mesh\rpk\rpk_30rnd.p3d";
         picture = "\hlc_wp_ak\tex\ui\gear_rpk_x_ca";
@@ -2084,42 +2088,42 @@ class CfgWeapons {
             };
             __AI_ROF_MG_SINGLE;
         };
-        class 50m : FullAuto{ 
-			__AI_ROF_MG_FULLAUTO; 
-        		}; 
-        class AI_long : 50m { 
-			showToPlayer = 0; 
-            aiBurstTerminable = 1; 
-			__AI_ROF_MG_LONG_BURST; 
-        		}; 
-		class AI_close: AI_long { 
-			__AI_ROF_MG_CLOSE_BURST; 
-        		}; 
-		class AI_short: AI_close { 
-			__AI_ROF_MG_SHORT_BURST; 
-        		}; 
-		class AI_medium: AI_close { 
-			__AI_ROF_MG_MEDIUM_BURST; 
-        		}; 
-		class AI_far: AI_close { 
-			__AI_ROF_MG_FAR_BURST; 
-        		}; 
-		class AI_toofar: AI_far { 
-			__AI_ROF_MG_VERYFAR_BURST; 
-        		}; 
-		class AI_far_optic1: AI_far { 
-			requiredOpticType = 1; 
-			__AI_ROF_MG_FAR_SCOPE_BURST; 
-        		}; 
-		class AI_toofar_optic1: AI_far_optic1 { 
-			__AI_ROF_MG_VERYFAR_SCOPE_BURST; 
-        		}; 
-		class AI_far_optic2: AI_far_optic1 { 
-			requiredOpticType = 2; 
-        		}; 
-		class AI_toofar_optic2: AI_toofar_optic1 { 
-			requiredOpticType = 2; 
-        		}; 
+        class 50m : FullAuto{
+			__AI_ROF_MG_FULLAUTO;
+        		};
+        class AI_long : 50m {
+			showToPlayer = 0;
+            aiBurstTerminable = 1;
+			__AI_ROF_MG_LONG_BURST;
+        		};
+		class AI_close: AI_long {
+			__AI_ROF_MG_CLOSE_BURST;
+        		};
+		class AI_short: AI_close {
+			__AI_ROF_MG_SHORT_BURST;
+        		};
+		class AI_medium: AI_close {
+			__AI_ROF_MG_MEDIUM_BURST;
+        		};
+		class AI_far: AI_close {
+			__AI_ROF_MG_FAR_BURST;
+        		};
+		class AI_toofar: AI_far {
+			__AI_ROF_MG_VERYFAR_BURST;
+        		};
+		class AI_far_optic1: AI_far {
+			requiredOpticType = 1;
+			__AI_ROF_MG_FAR_SCOPE_BURST;
+        		};
+		class AI_toofar_optic1: AI_far_optic1 {
+			__AI_ROF_MG_VERYFAR_SCOPE_BURST;
+        		};
+		class AI_far_optic2: AI_far_optic1 {
+			requiredOpticType = 2;
+        		};
+		class AI_toofar_optic2: AI_toofar_optic1 {
+			requiredOpticType = 2;
+        		};
 
         class WeaponSlotsInfo : WeaponSlotsInfo {
             mass = 96;
@@ -2317,7 +2321,7 @@ class CfgWeapons {
         hiddenSelections[] = { "Main", "Dovetail", "Mount", "GP30" };
         hiddenSelectionsTextures[] = { "hlc_wp_ak\tex\rifleman_aks\aks_co.tga", "hlc_wp_ak\tex\rifleman_ak74\mount_co.tga", "hlc_wp_ak\tex\rrxviii_mtk83\mtk-83_co.tga", "hlc_wp_ak\tex\gp30\gp30_co.tga" };
         muzzles[] = {"this", "hlc_GP30"};
-        bg_bipod = 0; 
+        bg_bipod = 0;
         class WeaponSlotsInfo: WeaponSlotsInfo {
             mass = 84;
         };
@@ -2361,6 +2365,7 @@ class CfgWeapons {
         displayName = "ZID AEK971S";
         model = "\hlc_wp_ak\mesh\aek971\aek971clean.p3d";
         picture = "\hlc_wp_ak\tex\ui\gear_aek_ca";
+        recoil = "recoil_aks"
         hiddenSelections[] = { "Main", "Mount" };
         hiddenSelectionsTextures[] = { "hlc_wp_ak\tex\mill_aek\bull5hit\aek971_co.tga", "hlc_wp_ak\tex\rrxviii_mtk83\mtk-83_co.tga" };
         reloadMagazineSound[] = { "hlc_wp_ak\snd\soundshaders\aek\aek_reload", 1, 1, 20 };
@@ -2369,7 +2374,7 @@ class CfgWeapons {
         cameraDir = "look";
         handAnim[] = { "OFP2_ManSkeleton", "hlc_wp_ak\anim\new_aks74uhandgesture.rtm" };
         discretedistanceinitindex = 0;
-        bg_bipod = 0; 
+        bg_bipod = 0;
         reloadAction = "HLC_GestureReloadAK545OneHand";
         modes[] = {"FullAuto","Burst","Single", "fullauto_medium", "single_medium_optics1", "single_far_optics2"};
         class FullAuto: Mode_FullAuto {
@@ -2525,7 +2530,7 @@ class CfgWeapons {
 
     class hlc_rifle_saiga12k : hlc_ak_base {
         dlc = "Niarms_AK";
-        recoil = "recoil_m320";
+        recoil = "recoil_MSBS65_ubs";
         ACE_barrelTwist = 0.0;
         ACE_twistDirection = 0;
         ACE_barrelLength = 429.26;
@@ -2541,7 +2546,7 @@ class CfgWeapons {
         discretedistance[] = {100,200,300,400};
         discretedistanceinitindex = 0;
         descriptionShort = "Shotgun<br/>Caliber:12 Gauge";
-        bg_bipod = 1; 
+        bg_bipod = 1;
         reloadMagazineSound[] = {"\hlc_wp_ak\snd\soundshaders\saiga\saiga_reload",0.9,1,30};
         modes[] = {"Single"};
         class Single: Mode_SemiAuto {
@@ -2599,6 +2604,8 @@ class CfgWeapons {
     class hlc_rifle_RK62 : hlc_ak_base {
         deployedPivot = "deploypivot";       /// what point should be used to be on surface while unfolded
         scope = public;
+        ACE_barrelLength = 418;
+        ACE_barrelTwist = 199.898;
         dlc = "Niarms_AK";
         author = "Nix";
         magazines[] = { __762x39_MAGS, __762x39_BI_MAGS };
@@ -2610,7 +2617,7 @@ class CfgWeapons {
         drysound[] = { "\hlc_wp_ak\snd\empty_assaultrifles", 1.5, 1, 10 };
         reloadMagazineSound[] = { "\hlc_wp_ak\snd\soundshaders\rk62\rk62_reload", 1, 1, 20 };
         reloadAction = "HLC_GestureReloadAK";
-        recoil = "recoil_mx";
+        recoil = "recoil_akm";
         class WeaponSlotsInfo : WeaponSlotsInfo {
             mass = 70;
             class MuzzleSlot : asdg_MuzzleSlot_762R {
@@ -3048,7 +3055,7 @@ class CfgWeapons {
         model = "\hlc_wp_ak\mesh\tigg_ak74m\ak74_mtk_60rnd.p3d";
         inertia = 0.36+0.109;
 		__DEXTERITY(3.6+1.09,0);
-        
+
     };
 
     class hlc_rifle_aek971_mtk : hlc_rifle_aek971 {

--- a/hlc_wp_fhAWC/config.cpp
+++ b/hlc_wp_fhAWC/config.cpp
@@ -760,7 +760,7 @@ class CfgWeapons {
     };
     class hlc_rifle_awMagnum_OD_ghillie : hlc_rifle_awmagnum {
         class WeaponSlotsInfo : WeaponSlotsInfo {
-            mass = 127;
+            mass = 151;
         };
         author = "toadie";
         displayName = $STR_NIA_rifle_AWM_OD_Ghillie;
@@ -769,7 +769,7 @@ class CfgWeapons {
     };
     class hlc_rifle_awMagnum_FDE_ghillie : hlc_rifle_awmagnum_FDE {
         class WeaponSlotsInfo : WeaponSlotsInfo {
-            mass = 127;
+            mass = 151;
         };
         author = "toadie";
         displayName = $STR_NIA_rifle_AWM_FDE_Ghillie;
@@ -778,7 +778,7 @@ class CfgWeapons {
     };
     class hlc_rifle_awMagnum_BL_ghillie : hlc_rifle_awmagnum_BL {
         class WeaponSlotsInfo : WeaponSlotsInfo {
-            mass = 127;
+            mass = 151;
         };
         author = "toadie";
         displayName = $STR_NIA_rifle_AWM_Black_Ghillie;

--- a/hlc_wp_fhAWC/config.cpp
+++ b/hlc_wp_fhAWC/config.cpp
@@ -760,7 +760,7 @@ class CfgWeapons {
     };
     class hlc_rifle_awMagnum_OD_ghillie : hlc_rifle_awmagnum {
         class WeaponSlotsInfo : WeaponSlotsInfo {
-            mass = 151;
+            mass = 127;
         };
         author = "toadie";
         displayName = $STR_NIA_rifle_AWM_OD_Ghillie;
@@ -769,7 +769,7 @@ class CfgWeapons {
     };
     class hlc_rifle_awMagnum_FDE_ghillie : hlc_rifle_awmagnum_FDE {
         class WeaponSlotsInfo : WeaponSlotsInfo {
-            mass = 151;
+            mass = 127;
         };
         author = "toadie";
         displayName = $STR_NIA_rifle_AWM_FDE_Ghillie;
@@ -778,7 +778,7 @@ class CfgWeapons {
     };
     class hlc_rifle_awMagnum_BL_ghillie : hlc_rifle_awmagnum_BL {
         class WeaponSlotsInfo : WeaponSlotsInfo {
-            mass = 151;
+            mass = 127;
         };
         author = "toadie";
         displayName = $STR_NIA_rifle_AWM_Black_Ghillie;

--- a/hlc_wp_g3/config.cpp
+++ b/hlc_wp_g3/config.cpp
@@ -1927,6 +1927,7 @@ class CfgWeapons {
         inertia = 0.36;
         __DEXTERITY(3.6, 0);
         class WeaponSlotsInfo {
+            mass = 71.5;
             class MuzzleSlot : asdg_MuzzleSlot_556 {
                 iconPosition[] = { 0.5, 0.35 };
                 iconScale = 0.0;
@@ -1944,7 +1945,7 @@ class CfgWeapons {
                 iconScale = 0.0;
             };
             class GripodSlot : nia_rifle_grips_slot {};
-            
+
         };
         rhs_grip1_change = "hlc_rifle_hk53RAS_grip";
         rhs_grip2_change = "hlc_rifle_hk53RAS_grip2";

--- a/hlc_wp_g36/config.cpp
+++ b/hlc_wp_g36/config.cpp
@@ -1,4 +1,4 @@
-// NOTE TO  FUTURE ME - 
+// NOTE TO  FUTURE ME -
 //G36 Rifle-length cycle - 0.093
 //Carbine = 0.88
 //Compact - 0.82
@@ -83,7 +83,7 @@ class niarms_XM8_PCAP_Underbarrel : UnderBarrelSlot {
     class compatibleItems {
     };
 };
-class CfgVehicles { 
+class CfgVehicles {
     dlc = "Niarms_G36";
     class B_supplyCrate_F;
     class HLC_G36_ammobox : B_supplyCrate_F {
@@ -766,7 +766,7 @@ class CfgWeapons {
             hasBipod = true;			/// bipod obviously has a bipod
             mass = 10;			/// what is the mass of the object
             soundBipodDown[] = { "A3\Sounds_F_Mark\arsenal\sfx\bipods\Bipod_BLU_down", db - 3, 1, 20 };	/// what sound should be played during unfolding
-            soundBipodUp[] = { "A3\Sounds_F_Mark\arsenal\sfx\bipods\Bipod_BLU_up", db - 3, 1, 20 };		/// what sound should be played during folding			
+            soundBipodUp[] = { "A3\Sounds_F_Mark\arsenal\sfx\bipods\Bipod_BLU_up", db - 3, 1, 20 };		/// what sound should be played during folding
         };
         inertia = 0.02;						/// how much does the bipod add to inertia of the weapon
     };
@@ -940,10 +940,10 @@ class CfgWeapons {
             __AI_ROF_RIFLE_SMALL_HSCOPE_SINGLE;
         };
         class AI_Burst_close : FullAuto {
-            
-                showToPlayer = 0; 
+
+                showToPlayer = 0;
                 aiBurstTerminable = 1;
-                burst = 4; 
+                burst = 4;
                 __AI_ROF_RIFLE_SMALL_CLOSE_BURST; \
         };
     };
@@ -1081,7 +1081,7 @@ class CfgWeapons {
         deployedpivot = "deploypivot";
         hasBipod = true;
         soundBipodDown[] = { "A3\Sounds_F_Mark\arsenal\sfx\bipods\Bipod_BLU_down", db - 3, 1, 20 };	/// what sound should be played during unfolding
-        soundBipodUp[] = { "A3\Sounds_F_Mark\arsenal\sfx\bipods\Bipod_BLU_up", db - 3, 1, 20 };		/// what sound should be played during folding			
+        soundBipodUp[] = { "A3\Sounds_F_Mark\arsenal\sfx\bipods\Bipod_BLU_up", db - 3, 1, 20 };		/// what sound should be played during folding
         recoil = "recoil_mk20";
         displayName = $STR_NIA_rifle_MG36;
         descriptionShort = $STR_NIA_MG36_DESC;
@@ -1233,9 +1233,9 @@ class CfgWeapons {
         dlc = "Niarms_G36";
         author = "Toadie";
         AB_barrelTwist = 12;
-        AB_barrelLength = 18.25;
+        AB_barrelLength = 9;
         ACE_barrelTwist = 178;
-        ACE_barrelLength = 318;
+        ACE_barrelLength = 228;
         scope = public;
         deployedpivot = "deploypivot";
         hasBipod = false;
@@ -1358,7 +1358,7 @@ class CfgWeapons {
             showToPlayer = 0;
             aiBurstTerminable = 1;
             burst = 4;
-            __AI_ROF_RIFLE_SMALL_CLOSE_BURST; 
+            __AI_ROF_RIFLE_SMALL_CLOSE_BURST;
         };
         class __MAGSWITCHCLASS {
             hlc_100rnd_556x45_EPR_G36 = "hlc_rifle_G36c_CMAG";
@@ -1781,9 +1781,9 @@ class CfgWeapons {
     class hlc_rifle_G36CV : hlc_rifle_G36V {
         dlc = "Niarms_G36";
         AB_barrelTwist = 12;
-        AB_barrelLength = 18.25;
+        AB_barrelLength = 9;
         ACE_barrelTwist = 178;
-        ACE_barrelLength = 318;
+        ACE_barrelLength = 228;
         author = "Toadie";
         displayName = $STR_NIA_rifle_G36CV;
         descriptionShort = $STR_NIA_G36_Compact_DESC;
@@ -2480,7 +2480,7 @@ class CfgWeapons {
         inertia = (0.28 + 0.21 + 0.066);
         __DEXTERITY((2.8 + 2.1 + 0.66), 1);
     };
-    ///CASELESS 
+    ///CASELESS
 
     class hlc_rifle_G36MLIC : hlc_G36_base {
         dlc = "Niarms_G36";
@@ -2853,7 +2853,7 @@ class CfgWeapons {
         };
         baseWeapon = "hlc_rifle_G36MLIAG36";
     };
-   
+
 
 
 };

--- a/hlc_wp_m14/config.cpp
+++ b/hlc_wp_m14/config.cpp
@@ -149,7 +149,7 @@ class CfgMagazines {
     class hlc_20Rnd_762x51_barrier_M14 : hlc_20Rnd_762x51_B_M14 {
         dlc = "Niarms_M14";
         author = "Toadie";
-        ammo = "HLC_762x51_MK316_20in";
+        ammo = "HLC_762x51_Barrier";
         descriptionshort = $STR_NIA_DESC_20Rnd_762x51_sost_fal;
         displayname = $STR_NIA_20rnd_762x51_SOST_M14;
         initspeed = 890.4;
@@ -476,7 +476,7 @@ class CfgWeapons {
         displayname = $STR_NIA_optic_M3a_M14;
 		tmr_optics_enhanced = 0; //prevent tmr_optics ARCO overlay from displaying
     };
-    
+
 //muzzles
 
     class muzzle_snds_H;
@@ -633,7 +633,7 @@ class CfgWeapons {
         discretedistance[] = { 100, 200, 300, 400, 500, 600 };
         discretedistanceinitindex = 2;
         discreteDistanceCameraPoint[] = { "eye", "eye2", "eye3", "eye4", "eye5", "eye6" }; /// the angle of gun changes with zeroing
-        bg_bipod = 0; 
+        bg_bipod = 0;
         handanim[] = {"OFP2_ManSkeleton", "\hlc_wp_m14\gesture\newgesture\gesture_m14.rtm"};
 
         class WeaponSlotsInfo : WeaponSlotsInfo {
@@ -686,7 +686,7 @@ class CfgWeapons {
         class WeaponSlotsInfo : WeaponSlotsInfo {
             mass = 91;
         };
-        
+
         class __MAGSWITCHCLASS {
             hlc_50Rnd_762x51_B_M14 = "hlc_rifle_M14_Bipod_XMAG";
             hlc_50Rnd_762x51_T_M14 = "hlc_rifle_M14_Bipod_XMAG";
@@ -772,7 +772,7 @@ class CfgWeapons {
         soundBipodUp[] = { "A3\Sounds_F_Mark\arsenal\sfx\bipods\Bipod_AAF_up", db - 3, 1, 20 }; /// sound of folding the bipod
         scope = public;
         recoil = "recoil_dmr_06";
-        agm_bipod = 1; 
+        agm_bipod = 1;
         cse_bipod = 1;
         model = "\hlc_wp_M14\mesh\m21\M14.p3d";
         hiddenSelections[] = { "Main", "Bipod", "rail" };
@@ -787,12 +787,12 @@ class CfgWeapons {
         memoryPointCamera = "eye"; /// the angle of gun changes with zeroing
         cameradir = "aim_point";
         discretedistanceinitindex = 2;
-        bg_bipod = 1; 
+        bg_bipod = 1;
         handanim[] = { "OFP2_ManSkeleton", "\hlc_wp_m14\gesture\newgesture\gesture_m14.rtm" };
         class WeaponSlotsInfo : WeaponSlotsInfo {
             mass = 109;
         };
-        
+
 
         class ItemInfo {
             priority = 1;
@@ -876,8 +876,8 @@ class CfgWeapons {
         hiddenSelectionsTextures[] = { "hlc_wp_m14\tex\bis_dmr\us_dmr_co.tga", "hlc_core\tex\acc\bipod\harris\harris1a2_co.tga"};
         __DEXTERITY(5.27 + 0.31, 0);
         inertia = 0.58;
-        agm_bipod = 1; 
-        hasbipod = true; 
+        agm_bipod = 1;
+        hasbipod = true;
         deployedpivot = "deploypivot";
         cse_bipod = 1;
         maxZeroing = 1600;
@@ -888,7 +888,7 @@ class CfgWeapons {
         discreteDistanceCameraPoint[] = { "eye", "eye2", "eye3", "eye4", "eye5", "eye6", "eye7", "eye8", "eye9" }; /// the angle of gun changes with zeroing
         cameradir = "aim_point";
         discretedistanceinitindex = 2;
-        bg_bipod = 1; 
+        bg_bipod = 1;
         handanim[] = { "OFP2_ManSkeleton", "\hlc_wp_m14\gesture\newgesture\gesture_m14DMR.rtm" };
         class Single : Single{
             __MOA(1.1);
@@ -941,8 +941,8 @@ class CfgWeapons {
         AB_barrelLength=18;
         ACE_barrelTwist = 304.8;
         ACE_barrelLength = 457.2;
-        agm_bipod = 1; 
-        hasbipod = 1; 
+        agm_bipod = 1;
+        hasbipod = 1;
         cse_bipod = 1;
         maxZeroing = 1600;
         model = "\hlc_wp_M14\mesh\sopmod\M14.p3d";
@@ -956,7 +956,7 @@ class CfgWeapons {
         cameradir = "aim_point";
         recoil = "recoil_ebr";
         discretedistanceinitindex = 2;
-        bg_bipod = 1; 
+        bg_bipod = 1;
         initspeed = -0.966;
         handanim[] = { "OFP2_ManSkeleton", "\hlc_wp_m14\gesture\newgesture\gesture_m14SOPMOD_STD.rtm" };
         class WeaponSlotsInfo : WeaponSlotsInfo {

--- a/hlc_wp_m16a2/config.cpp
+++ b/hlc_wp_m16a2/config.cpp
@@ -145,9 +145,11 @@ class CfgWeapons
 	class hlc_wp_m16a2 :Rifle_Base_F
 	{
 
-		
+
 		scope = public;
-		magazines[] = { 			
+		ACE_barrelLength = 508‬;
+		ACE_barrelTwist = 178;
+		magazines[] = {
             __556STANAG_MAGS,__556STANAG_BI_MAGS
 		};
         magazineWell[] = { STANAG_556x45, "CBA_556x45_STANAG", "CBA_556x45_STANAG_L", "CBA_556x45_STANAG_XL", "CBA_556x45_STANAG_2D", "CBA_556x45_STANAG_2D_XL" };
@@ -318,7 +320,7 @@ class CfgWeapons
         scopeArsenal = 0;
         reloadAction = "NIA_GestureReload416_x15";
         inertia = 0.358 + 0.19;
-        __DEXTERITY(3.58 + 1.9, 0); //afg,kx3   
+        __DEXTERITY(3.58 + 1.9, 0); //afg,kx3
     };
 	class hlc_rifle_m203 : hlc_wp_m16a2
 	{
@@ -353,7 +355,7 @@ class CfgWeapons
         scopeArsenal = 0;
         reloadAction = "NIA_GestureReload416_x15";
         inertia = 0.506 + 0.19;
-        __DEXTERITY(5.06 + 1.9, 0); //afg,kx3   
+        __DEXTERITY(5.06 + 1.9, 0); //afg,kx3
     };
 
 	class hlc_wp_XM177E2 :Rifle_Base_F
@@ -361,6 +363,8 @@ class CfgWeapons
 
 
 		scope = public;
+		ACE_barrelLength = 368.3‬;
+		ACE_barrelTwist = 178;
 		magazines[] = {
 			//Standard BIS mags
             __556STANAG_MAGS, __556STANAG_BI_MAGS
@@ -525,13 +529,15 @@ class CfgWeapons
         scopeArsenal = 0;
         reloadAction = "NIA_GestureReload416_x15";
         inertia = 0.308 + 0.19;
-        __DEXTERITY(3.08 + 1.9, 0); //afg,kx3   
+        __DEXTERITY(3.08 + 1.9, 0); //afg,kx3
     };
 	class hlc_wp_mod727 :Rifle_Base_F
 	{
 
 
 		scope = public;
+		ACE_barrelLength = 368.3‬;
+		ACE_barrelTwist = 178;
 		magazines[] = {
 			//Standard BIS mags
             __556STANAG_MAGS, __556STANAG_BI_MAGS
@@ -699,7 +705,7 @@ class CfgWeapons
         scopeArsenal = 0;
         reloadAction = "NIA_GestureReload416_x15";
         inertia = 0.277 + 0.19;
-        __DEXTERITY(2.77 + 1.9, 0); //afg,kx3   
+        __DEXTERITY(2.77 + 1.9, 0); //afg,kx3
     };
     class hlc_wp_mod733 :Rifle_Base_F
     {
@@ -882,7 +888,7 @@ class CfgWeapons
         scopeArsenal = 0;
         reloadAction = "NIA_GestureReload416_x15";
         inertia = 0.22 + 0.19;
-        __DEXTERITY(2.22 + 1.9, 0); //afg,kx3   
+        __DEXTERITY(2.22 + 1.9, 0); //afg,kx3
     };
 	class hlc_wp_m16A1: hlc_wp_m16a2
 	{
@@ -985,7 +991,7 @@ class CfgWeapons
         scopeArsenal = 0;
         reloadAction = "NIA_GestureReload416_x15";
         inertia = 0.289 + 0.19;
-        __DEXTERITY(2.89 + 1.9, 0); //afg,kx3   
+        __DEXTERITY(2.89 + 1.9, 0); //afg,kx3
     };
 	class hlc_rifle_A1m203 : hlc_wp_m16A1
 	{
@@ -1016,13 +1022,15 @@ class CfgWeapons
         scopeArsenal = 0;
         reloadAction = "NIA_GestureReload416_x15";
         inertia = 0.425 + 0.19;
-        __DEXTERITY(4.25 + 1.9, 0); //afg,kx3   
+        __DEXTERITY(4.25 + 1.9, 0); //afg,kx3
     };
 	class hlc_wp_xm4 :Rifle_Base_F
     {
 
 
         scope = public;
+				ACE_barrelLength = 368.3‬;
+				ACE_barrelTwist = 178;
         magazines[] = {
             //Standard BIS mags
             __556STANAG_MAGS, __556STANAG_BI_MAGS
@@ -1188,6 +1196,6 @@ class CfgWeapons
         scopeArsenal = 0;
         reloadAction = "NIA_GestureReload416_x15";
         inertia = 0.277 + 0.19;
-        __DEXTERITY(2.77 + 1.9, 0); //afg,kx3   
+        __DEXTERITY(2.77 + 1.9, 0); //afg,kx3
     };
 };

--- a/hlc_wp_saw/config.cpp
+++ b/hlc_wp_saw/config.cpp
@@ -224,7 +224,7 @@ class CfgVehicles {
 
 class CfgMagazines{
     class 30Rnd_556x45_Stanag;
-        
+
     class hlc_200rnd_556x45_M_SAW : 30Rnd_556x45_Stanag {
         dlc = "Niarms_SAW";
         author = "Toadie, Spartan0536";
@@ -314,6 +314,7 @@ class CfgWeapons {
         magazines[] = {};
         maxRecoilSway = 0.0125;
         swayDecaySpeed = 1.25;
+        recoil = "recoil_saw";
         class GunParticles : GunParticles {
 
             class SecondEffect {
@@ -466,7 +467,7 @@ class CfgWeapons {
         picture = "\hlc_wp_saw\tex\ui\gear_minimipara_x_ca";
         hiddenSelections[] = { "Reciever", "Assembly_cover", "Barrel", "Misc", "Foregrip", "Stock", "RearSight", "Magazine", "VFG" };
         hiddenSelectionsTextures[] = { "hlc_wp_saw\tex\toadie_m249\reciever_minimi_co.tga", "hlc_wp_saw\tex\toadie_m249\assemblycover_co.tga", "hlc_wp_saw\tex\toadie_m249\barrel_co.tga", "hlc_wp_saw\tex\toadie_m249\misc_co.tga", "hlc_wp_saw\tex\toadie_m249\fore_co.tga", "hlc_wp_saw\tex\toadie_m249\stockmap_co.tga", "hlc_wp_saw\tex\toadie_m249\rearsight_co.tga", "hlc_wp_saw\tex\toadie_m249\pouch_auscam_co.tga", "" };
-        
+
         discretedistance[] = { 100, 200, 300, 400, 500, 600, 700, 800 };
         discretedistanceinitindex = 2;
         bg_bipod = 1;
@@ -3061,17 +3062,17 @@ class CfgWeapons {
         deployedPivot = "deploypoint";
         inertia = 0.57;
         __DEXTERITY(5.71 + 0.3, 0);
-        ACE_barrelTwist = 305;
-        ACE_barrelLength = 405;
-        AB_barrelTwist = 12;
-        AB_barrelLength = 16;
+        ACE_barrelTwist = 177.8;
+        ACE_barrelLength = 414;
+        AB_barrelTwist = 7;
+        AB_barrelLength = 16.3
         initspeed = -0.976216;
         magazines[] = { __556NATO_BELTS, __556NATO_BI_BELTS };
         magazineWell[] = {"CBA_556x45_MINIMI"};
         hiddenSelections[] = { "Reciever", "Assembly_cover", "Barrel", "Misc", "Foregrip", "Stock", "RearSight", "Magazine", "VFG", "Rail", "Bipod" };
         hiddenSelectionsTextures[] = { "hlc_wp_saw\tex\mk48\reciever_mk48_co.tga", "hlc_wp_saw\tex\toadie_m249\assemblycover_co.tga", "hlc_wp_saw\tex\toadie_m249\barrel_co.tga", "hlc_wp_saw\tex\toadie_m249\misc_co.tga", "hlc_wp_saw\tex\toadie_m249\PIP_Foregrip_co.tga", "hlc_wp_saw\tex\toadie_m249\stockmap_co.tga", "hlc_wp_saw\tex\toadie_m249\rearsight_co.tga", "hlc_wp_saw\tex\toadie_m249\amoobox_co.tga", "hlc_wp_saw\tex\melon_vfg\vgrip_co.tga", "hlc_wp_saw\tex\mk48\mk48_quadrail_co.tga", "hlc_wp_saw\tex\toadie_m249\pipbipod_co.tga" };
         class WeaponSlotsInfo {
-            mass = 119;
+            mass = 126;
             class CowsSlot : asdg_OpticRail1913_short_MG {
                 iconPosition[] = { 0.5, 0.3 };
             };
@@ -3081,14 +3082,14 @@ class CfgWeapons {
             };
             class PointerSlot : asdg_FrontSideRail {
                 iconPosition[] = { 0.2, 0.4 };
-            };             
+            };
             class UnderBarrelSlot : asdg_UnderSlot {};
             class GripodSlot : nia_rifle_grips_slot {};
         };
         class FullAuto : FullAuto {
 
             __ROF(730);
-            dispersion = 0.000261799;
+            dispersion = 0.000349056;
         };
         class __MAGSWITCHCLASS {};
         rhs_grip1_change = "hlc_lmg_mk46_grip";
@@ -3131,7 +3132,7 @@ class CfgWeapons {
         inertia = 0.55;
         __DEXTERITY(5.5 + 0.3, 0);
         class WeaponSlotsInfo : WeaponSlotsInfo {
-            mass = 112;
+            mass = 154.4;
         };
         class __MAGSWITCHCLASS {};
         rhs_grip1_change = "hlc_lmg_mk46mod1_grip";
@@ -3169,9 +3170,9 @@ class CfgWeapons {
         scope = public;
         agm_bipod = 1;
         ACE_barrelTwist = 305;
-        ACE_barrelLength = 465;
+        ACE_barrelLength = 501.7;
         AB_barrelTwist = 12;
-        AB_barrelLength = 18.3;
+        AB_barrelLength = 19.75;
         AGM_Overheating_Dispersion[] = { 0, -0.001, 0.001, 0.003 };
         AGM_Overheating_SlowdownFactor[] = { 1, 1, 1, 0.9 };
         AGM_Overheating_JamChance[] = { 0, 0.0003, 0.0015, 0.0075 };
@@ -3199,7 +3200,7 @@ class CfgWeapons {
             };
         };
         class WeaponSlotsInfo  {
-            mass = 172;
+            mass = 186.4;
             class UnderBarrelSlot : asdg_UnderSlot {};
             class GripodSlot : nia_rifle_grips_slot {};
             class CowsSlot : asdg_OpticRail1913_short_MG {
@@ -3233,9 +3234,9 @@ class CfgWeapons {
                 soundSetShot[] = { "mk48_silencerShot_SoundSet", "mk48_silencerTail_SoundSet" };
             };
             reloadTime = 0.084;
-            dispersion = 0.000261799;
+            dispersion = 0.000349056;
             __AI_ROF_MG_FULLAUTO;
-        }; 
+        };
         class short : close{
             __AI_ROF_MG_CLOSE_BURST;
         };
@@ -3317,13 +3318,17 @@ class CfgWeapons {
         hiddenSelectionsTextures[] = { "hlc_wp_saw\tex\mk48\reciever_mk48_co.tga", "hlc_wp_saw\tex\toadie_m249\assemblycover_co.tga", "hlc_wp_saw\tex\toadie_m249\barrel_co.tga", "hlc_wp_saw\tex\toadie_m249\misc_co.tga", "hlc_wp_saw\tex\toadie_m249\PIP_Foregrip_co.tga", "hlc_wp_saw\tex\toadie_m249\stockmap_co.tga", "hlc_wp_saw\tex\toadie_m249\rearsight_co.tga", "hlc_wp_saw\tex\toadie_m249\pouch_auscam_co.tga", "hlc_wp_saw\tex\melon_vfg\vgrip_co.tga", "hlc_wp_saw\tex\mk48\mk48_quadrail_co.tga", "hlc_wp_saw\tex\toadie_m249\pipbipod_co.tga" };
         class WeaponSlotsInfo : WeaponSlotsInfo {
             mass = 185;
-            
+
         };
         class __MAGSWITCHCLASS {};
         rhs_grip1_change = "hlc_lmg_mk48mod1_grip";
         rhs_grip2_change = "hlc_lmg_mk48mod1_grip2";
         rhs_grip3_change = "hlc_lmg_mk48mod1_grip3";
         baseWeapon = "hlc_lmg_mk48mod1";
+        class FullAuto: FullAuto
+        {
+          __ROF(625);
+        };
     };
 
     class hlc_lmg_mk48mod1_grip : hlc_lmg_mk48mod1

--- a/hlc_wp_saw/config.cpp
+++ b/hlc_wp_saw/config.cpp
@@ -869,7 +869,7 @@ class CfgWeapons {
     {
         author = "Toadie";
         model = "\hlc_wp_saw\mesh\minimi_para\minimi_para_longer_railed.p3d";
-        displayName = $STR_NIA_lmg_minimipara_railed;
+        displayName = $STR_NIA_lmg_minimipara_long_railed;
         initspeed = -1;
         inertia = 0.69;
         __DEXTERITY(6.94, 0);

--- a/hlc_wp_saw/stringtable.xml
+++ b/hlc_wp_saw/stringtable.xml
@@ -47,7 +47,7 @@
         <Korean>FN Minimi Para (Long)</Korean>
         <Chinesesimp>FN Minimi Para (Long)</Chinesesimp>
       </Key>
-      <Key ID="STR_NIA_lmg_minimipara_railed">
+      <Key ID="STR_NIA_lmg_minimipara_long_railed">
         <Original>FN Minimi Para (Long/RIS)</Original>
         <English>FN Minimi Para (Long/RIS)</English>
         <Czech>FN Minimi Para (Long/RIS)</Czech>
@@ -61,7 +61,7 @@
         <Japanese>FN Minimi Para (長身/RIS)</Japanese>
         <Korean>FN Minimi Para (Long/RIS)</Korean>
         <Chinesesimp>FN Minimi Para (Long/RIS)</Chinesesimp>
-      </Key>      
+      </Key>
       <Key ID="STR_NIA_lmg_minimi">
         <Original>FN Minimi (Long)</Original>
         <English>FN Minimi (Long)</English>
@@ -91,7 +91,7 @@
         <Japanese>FN Minimi (長身/RIS)</Japanese>
         <Korean>FN Minimi (Long/RIS)</Korean>
         <Chinesesimp>FN Minimi (Long/RIS)</Chinesesimp>
-      </Key>      
+      </Key>
       <Key ID="STR_NIA_lmg_m249para">
         <Original>M249E2 Para (Short)</Original>
         <English>M249E2 Para (Short)</English>
@@ -106,7 +106,7 @@
         <Japanese>M249E2 Para (短身)</Japanese>
         <Korean>M249E2 Para (Short)</Korean>
         <Chinesesimp>M249E2 Para (Short)</Chinesesimp>
-      </Key>     
+      </Key>
       <Key ID="STR_NIA_lmg_M249E2">
         <Original>M249E2</Original>
         <English>M249E2</English>
@@ -151,7 +151,7 @@
         <Japanese>M249 PIP (長身/RIS)</Japanese>
         <Korean>M249 PIP (Long/RIS)</Korean>
         <Chinesesimp>M249 PIP (Long/RIS)</Chinesesimp>
-      </Key>  
+      </Key>
       <Key ID="STR_NIA_m249_pip2">
         <Original>M249E2 (Short/RIS)</Original>
         <English>M249E2 (Short/RIS)</English>
@@ -166,7 +166,7 @@
         <Japanese>M249E2 (短身/RIS)</Japanese>
         <Korean>M249E2 (Short/RIS)</Korean>
         <Chinesesimp>M249E2 (Short/RIS)</Chinesesimp>
-      </Key>  
+      </Key>
       <Key ID="STR_NIA_m249_pip3">
         <Original>M249 PIP (Short/RIS)</Original>
         <English>M249 PIP (Short/RIS)</English>
@@ -181,7 +181,7 @@
         <Japanese>M249 PIP (短身/RIS)</Japanese>
         <Korean>M249 PIP (Short/RIS)</Korean>
         <Chinesesimp>M249 PIP (Short/RIS)</Chinesesimp>
-      </Key>  
+      </Key>
       <Key ID="STR_NIA_m249_pip4">
         <Original>M249 PIP (Long/RIS)</Original>
         <English>M249 PIP (Long/RIS)</English>
@@ -196,7 +196,7 @@
         <Japanese>M249 PIP (長身/RIS)</Japanese>
         <Korean>M249 PIP (Long/RIS)</Korean>
         <Chinesesimp>M249 PIP (Long/RIS)</Chinesesimp>
-      </Key>  
+      </Key>
       <Key ID="STR_NIA_m249_SQuantoon">
         <Original>M249 &quot;Squantoon Special&quot; (Long/RIS)</Original>
         <English>M249 &quot;Squantoon Special&quot; (Long/RIS)</English>
@@ -211,7 +211,7 @@
         <Japanese>M249 &quot;Squantoon Special&quot; (長身/RIS)</Japanese>
         <Korean>M249 &quot;Squantoon Special&quot; (Long/RIS)</Korean>
         <Chinesesimp>M249 &quot;Squantoon Special&quot; (Long/RIS)</Chinesesimp>
-      </Key>  
+      </Key>
       <Key ID="STR_NIA_mk46mod0">
         <Original>Mk 46 Mod 0</Original>
         <English>Mk 46 Mod 0</English>
@@ -226,7 +226,7 @@
         <Japanese>Mk 46 Mod 0</Japanese>
         <Korean>Mk 46 Mod 0</Korean>
         <Chinesesimp>Mk 46 Mod 0</Chinesesimp>
-      </Key>  
+      </Key>
       <Key ID="STR_NIA_mk46mod1">
         <Original>Mk 46 Mod 1</Original>
         <English>Mk 46 Mod 1</English>
@@ -241,7 +241,7 @@
         <Japanese>Mk 46 Mod 1</Japanese>
         <Korean>Mk 46 Mod 1</Korean>
         <Chinesesimp>Mk 46 Mod 1</Chinesesimp>
-      </Key> 
+      </Key>
       <Key ID="STR_NIA_mk48mod0">
         <Original>Mk 48 Mod 0</Original>
         <English>Mk 48 Mod 0</English>
@@ -256,7 +256,7 @@
         <Japanese>Mk 48 Mod 0</Japanese>
         <Korean>Mk 48 Mod 0</Korean>
         <Chinesesimp>Mk 48 Mod 0</Chinesesimp>
-      </Key> 
+      </Key>
       <Key ID="STR_NIA_mk48mod1">
         <Original>Mk 48 Mod 1</Original>
         <English>Mk 48 Mod 1</English>
@@ -271,7 +271,7 @@
         <Japanese>Mk 48 Mod 1</Japanese>
         <Korean>Mk 48 Mod 1</Korean>
         <Chinesesimp>Mk 48 Mod 1</Chinesesimp>
-      </Key> 
+      </Key>
     </Container>
     <Container name="Acc_names">
       <Key ID="STR_NIA_bipod_SAW_VFG">
@@ -367,7 +367,7 @@
         <Japanese>軽機関銃&lt;br/&gt;口径: 5.56mm NATO</Japanese>
         <Korean>Light Machine Gun&lt;br/&gt;Caliber:5.56mm NATO</Korean>
         <Chinesesimp>Light Machine Gun&lt;br/&gt;Caliber:5.56mm NATO</Chinesesimp>
-      </Key> 
+      </Key>
       <Key ID="STR_NIA_Mk46_DESC">
         <Original>Special Purpose Weapon&lt;br/&gt;Caliber:5.56mm NATO</Original>
         <English>Special Purpose Weapon&lt;br/&gt;Caliber:5.56mm NATO</English>


### PR DESCRIPTION
When merged, this PR will:
* Correct Ghillie AWM's to no longer have magically less mass than their non-ghillie versions
* Add ACE Ballistics data to all weapons in hlc_wp_m16a2
* Add missing mass value to hlc_rifle_hk53RAS
* Add missing or correct existing ACE Ballistics values in hlc_wp_AK
* Add missing or correct existing ACE Ballistics values in hlc_wp_FAL
* Correct existing ACE Ballistics values in hlc_wp_g36
* Correct mass and ROF values in hlc_lmg_mk46, hlc_lmg_mk46mod1, hlc_lmg_mk48, and hlc_lmg_mk48mod1
* Apply proper BI recoils to hlc_wp_AK
* Apply missing recoil_saw to hlc_wp_saw
* Apply proper name string to hlc_lmg_minimipara_long_railed
* Apply proper ammo type to M14 SOST magazines
* Correct ballistics for HLC_300Blackout_SMK
* Correct STR_NIA_50Rnd_300BLK_M_STANAG to display proper ammo name in X-15 magazine
* Update list of compatible RHS grips