### PR TITLE
MGs - ACE Overheating closed bolt compatibility

### DIFF
--- a/hlc_wp_m60E4/config.cpp
+++ b/hlc_wp_m60E4/config.cpp
@@ -81,6 +81,7 @@ class CfgWeapons {
     class hlc_M60e4_base : Rifle_Base_F {
         dlc = "Niarms_M60";
         ACE_Overheating_allowSwapBarrel = 1;
+        ACE_Overheating_closedBolt = 0;
         ACE_Overheating_Dispersion[] = { 0, -0.001, 0.001, 0.003 };
         ACE_Overheating_SlowdownFactor[] = { 1, 1, 1, 0.9 };
         ACE_Overheating_JamChance[] = { 0, 0.0003, 0.0015, 0.0075 };

--- a/hlc_wp_mg3/config.cpp
+++ b/hlc_wp_mg3/config.cpp
@@ -780,6 +780,7 @@ class CfgWeapons {
     {
         dlc = "Niarms_MG3";
         ACE_Overheating_allowSwapBarrel = 1;
+        ACE_Overheating_closedBolt = 0;
         ACE_Overheating_Dispersion[] = { 0, -0.001, 0.001, 0.003 };
         ACE_Overheating_SlowdownFactor[] = { 1, 1, 1, 0.9 };
         ACE_Overheating_JamChance[] = { 0, 0.0003, 0.0015, 0.0075 };

--- a/hlc_wp_saw/config.cpp
+++ b/hlc_wp_saw/config.cpp
@@ -307,6 +307,7 @@ class CfgWeapons {
         author = "Toadie";
         scope = protected;
         ACE_Overheating_allowSwapBarrel = 1;
+        ACE_Overheating_closedBolt = 0;
         ACE_Overheating_Dispersion[] = { 0, -0.001, 0.001, 0.003 };
         ACE_Overheating_SlowdownFactor[] = { 1, 1, 1, 0.9 };
         ACE_Overheating_JamChance[] = { 0, 0.0003, 0.0015, 0.0075 };


### PR DESCRIPTION
Add `ACE_Overheating_closedBolt` property to MGs base classes to make them act like open bolt systems in regards to `ACE Overheating`

Close https://github.com/toadie2k/NIArms/issues/174